### PR TITLE
Strip leading 0s to prevent octal interpretation

### DIFF
--- a/src/adr-new
+++ b/src/adr-new
@@ -57,7 +57,7 @@ fi
 
 if [ -d $dstdir ]
 then
-    maxid=$(ls $dstdir | grep -Eo '^[0-9]+' | sort -rn | head -1)
+    maxid=$(ls $dstdir | grep -Eo '^[0-9]+' | sed -e 's/^0*//' | sort -rn | head -1)
     newnum=$(($maxid + 1))
 else
     newnum=1

--- a/tests/avoid-octal-numbers.expected
+++ b/tests/avoid-octal-numbers.expected
@@ -1,0 +1,36 @@
++ adr new First Decision
+doc/adr/0001-first-decision.md
++ adr new Second Decision
+doc/adr/0002-second-decision.md
++ adr new Third Decision
+doc/adr/0003-third-decision.md
++ adr new Fourth Decision
+doc/adr/0004-fourth-decision.md
++ adr new Fifth Decision
+doc/adr/0005-fifth-decision.md
++ adr new Sixth Decision
+doc/adr/0006-sixth-decision.md
++ adr new Seventh Decision
+doc/adr/0007-seventh-decision.md
++ adr new Eighth Decision
+doc/adr/0008-eighth-decision.md
++ adr new Ninth Decision
+doc/adr/0009-ninth-decision.md
++ ls doc/adr
+0001-first-decision.md
+0002-second-decision.md
+0003-third-decision.md
+0004-fourth-decision.md
+0005-fifth-decision.md
+0006-sixth-decision.md
+0007-seventh-decision.md
+0008-eighth-decision.md
+0009-ninth-decision.md
++ head -7 doc/adr/0009-ninth-decision.md
+# 9. Ninth Decision
+
+Date: 12/01/1992
+
+## Status
+
+Accepted

--- a/tests/avoid-octal-numbers.sh
+++ b/tests/avoid-octal-numbers.sh
@@ -1,0 +1,11 @@
+adr new First Decision
+adr new Second Decision
+adr new Third Decision
+adr new Fourth Decision
+adr new Fifth Decision
+adr new Sixth Decision
+adr new Seventh Decision
+adr new Eighth Decision
+adr new Ninth Decision
+ls doc/adr
+head -7 doc/adr/0009-ninth-decision.md


### PR DESCRIPTION
I found I was unable to create more than 8 records because the adr-new code to increment the counter interpreted 0008 as an invalid octal number. Fix was to strip leading zeroes to force decimal interpretation.