### PR TITLE
Add ADR_TEMPLATES_DIR env var to customize templates path

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ ADRs are stored in your project as Markdown files in the `doc/adr` directory.
 
         adr help
 
+Customizing
+-----------
+
+Set the environment variable ADR_TEMPLATES_DIR to a folder containing two
+files: template.md and init.md.
 
 See the [tests](tests/) for detailed examples.
 

--- a/src/adr-init
+++ b/src/adr-init
@@ -9,5 +9,6 @@ set -e
 ##  * creates the first ADR in that subdirectory, recording the decision to
 ##    record architectural decisions with ADRs.
 
-VISUAL=true ADR_TEMPLATE="$(dirname $0)/init.md" \
+templates_dir=${ADR_TEMPLATES_DIR:-$(dirname $0)}
+VISUAL=true ADR_TEMPLATE="$templates_dir/init.md" \
       adr new record-architecture-decisions

--- a/src/adr-new
+++ b/src/adr-new
@@ -44,7 +44,8 @@ do
     esac
 done
 
-template=${ADR_TEMPLATE:-$(dirname $0)/template.md}
+templates_dir=${ADR_TEMPLATES_DIR:-$(dirname $0)}
+template=${ADR_TEMPLATE:-$templates_dir/template.md}
 dstdir=$($(dirname $0)/_adr_dir)
 
 title="$@"

--- a/tests/alternative-adr-templates-directory.expected
+++ b/tests/alternative-adr-templates-directory.expected
@@ -1,0 +1,8 @@
++ mkdir templates-dir
++ echo 'Hello template'
++ ADR_TEMPLATES_DIR=templates-dir
++ export ADR_TEMPLATES_DIR
++ adr new Example
+doc/adr/0001-example.md
++ head -1 doc/adr/0001-example.md
+Hello template

--- a/tests/alternative-adr-templates-directory.sh
+++ b/tests/alternative-adr-templates-directory.sh
@@ -1,0 +1,10 @@
+mkdir templates-dir
+echo "Hello template" > templates-dir/template.md
+
+ADR_TEMPLATES_DIR=templates-dir
+export ADR_TEMPLATES_DIR
+
+adr new Example
+
+head -1 doc/adr/0001-example.md
+


### PR DESCRIPTION
Addressing #2 - this will make it easier to `inreplace` in the package managers' scripts.

I tried using it, like this:

```shell
$ mkdir ~/slask/t/
$ cp src/*.md ~/slask/t/
$ vi ~/slask/t/init.md
$ ADR_TEMPLATES_DIR=~/slask/t ./adr-init
```

(Slask is Swedish for "mush" or "sleet".)

- [x] add an expected output test