### PR TITLE
Use less ambigious time format

### DIFF
--- a/src/adr-new
+++ b/src/adr-new
@@ -76,7 +76,7 @@ fi
 newid=$(printf "%04d" $newnum)
 slug=$(echo -n $title | tr -Ccs [:alnum:] - | tr [:upper:] [:lower:] | sed -e 's/[^[:alnum:]]*$//' -e 's/^[^[:alnum:]]*//')
 dstfile=$dstdir/$newid-$slug.md
-date=${ADR_DATE:-$(date +%d/%m/%Y)}
+date=${ADR_DATE:-$(date +%Y-%m-%d)}
 
 if [ ! -z $superceded ]
 then


### PR DESCRIPTION
Instead of using `%d/%m/%Y`, which can be confused to `%m/%d/%Y` (especially in US), use ISO8601 date format `%Y-%m-%d`
