### PR TITLE
Fixes for Arch

### DIFF
--- a/src/_adr_commands
+++ b/src/_adr_commands
@@ -2,4 +2,4 @@
 set -e
 source "$(dirname $0)/config.sh"
 
-(cd "$adr_bin_dir" && find . -name 'adr-*' -perm +111) | cut -c 7-
+(cd "$adr_bin_dir" && find . -name 'adr-*' -perm /111) | cut -c 7-

--- a/src/adr-generate
+++ b/src/adr-generate
@@ -13,7 +13,7 @@ cmd=$1
 
 if [ -z $cmd ]
 then
-    (cd "$adr_bin_dir" && find . -name '_adr_generate_*' -perm +111) | cut -c 17-
+    (cd "$adr_bin_dir" && find . -name '_adr_generate_*' -perm /111) | cut -c 17-
 else
     "$adr_bin_dir/_adr_generate_$cmd" "${@:2}"
 fi

--- a/src/adr-list
+++ b/src/adr-list
@@ -10,7 +10,7 @@ adr_dir=$("$adr_bin_dir/_adr_dir")
 
 if [ -d $adr_dir ]
 then
-   find $adr_dir | grep -E "^$adr_dir/[0-9]+-[^/]*\\.md"
+   find $adr_dir | grep -E "^$adr_dir/[0-9]+-[^/]*\\.md" | sort
 else
     echo "The $adr_dir directory does not exist"
     exit 1

--- a/src/adr-new
+++ b/src/adr-new
@@ -76,7 +76,7 @@ fi
 newid=$(printf "%04d" $newnum)
 slug=$(echo -n $title | tr -Ccs [:alnum:] - | tr [:upper:] [:lower:] | sed -e 's/[^[:alnum:]]*$//' -e 's/^[^[:alnum:]]*//')
 dstfile=$dstdir/$newid-$slug.md
-date=${ADR_DATE:-$(date +%d/%m/%Y)}
+date=${ADR_DATE:-$(date --iso-8601)}
 
 if [ ! -z $superceded ]
 then


### PR DESCRIPTION
Hi, thanks for these tools! I found a couple of problems when running them on Arch Linux.

1. According to my version of `find`, the `+` operator is no longer supported, and the man page recommends to use `/` instead.
2. The tests failed to run due to `find` giving an undefined order of output. Adding a `sort` fixed it for me.
3. My team at work have started using these tools, and for our purposes we decided to change the date format to ISO-8601, which prevents any ambiguity that might arise from people in different locations. I'm adding it here in case you'd like to do the same -  I realise this one's partially a matter of taste!

I have only tested these on my own machine (Arch Linux). If you want to accept only one or two of the changes, I can split them into separate pull requests if you like.