### PR TITLE
Make _adr_commands GNU compatible

### DIFF
--- a/src/_adr_commands
+++ b/src/_adr_commands
@@ -2,4 +2,4 @@
 set -e
 source "$(dirname $0)/config.sh"
 
-(cd "$adr_bin_dir" && find . -name 'adr-*' -perm +111) | cut -c 7-
+(cd "$adr_bin_dir" && find . -name 'adr-*' -perm /u=x,g=x,o=x) | cut -c 7-

--- a/src/adr-generate
+++ b/src/adr-generate
@@ -13,7 +13,7 @@ cmd=$1
 
 if [ -z $cmd ]
 then
-    (cd "$adr_bin_dir" && find . -name '_adr_generate_*' -perm +111) | cut -c 17-
+    (cd "$adr_bin_dir" && find . -name '_adr_generate_*' -perm /u=x,g=x,o=x) | cut -c 17-
 else
     "$adr_bin_dir/_adr_generate_$cmd" "${@:2}"
 fi


### PR DESCRIPTION
`adr help` fails on my Ubuntu bash with

```
usage: ./adr-help COMMAND [ARG] ...
COMMAND is one of: 
find: invalid mode ‘+111’
Run 'adr help COMMAND' for help on a specific command.
```
I think this `-perm` syntax will work for BSD too