### PR TITLE
Use ISO 8601 dates.

### DIFF
--- a/doc/adr/0007-use-iso-8601-date-format.md
+++ b/doc/adr/0007-use-iso-8601-date-format.md
@@ -1,0 +1,45 @@
+# 7. Use ISO 8601 Date Format
+
+Date: 07/11/2016
+
+## Status
+
+Proposed
+
+## Context
+
+`adr-tools` seeks to communicate the history of architectural decisions of a
+project.  An important component of the history is the time at which a decision
+was made.
+
+To communicate effectively, `adr-tools` should present information as
+unambiguously as possible.  That means that culture-neutral data formats should
+be preferred over culture-specific formats.
+
+Existing `adr-tools` deployments format  dates as `dd/mm/yyyy` by default.  That
+formatting is common formatting in the United Kingdom (where the `adr-tools`
+project was originally written), but is easily confused with the `mm/dd/yyyy`
+format preferred in the United States.
+
+The default date format may be overridden by setting `ADR_DATE` in `config.sh`.
+
+## Decision
+
+`adr-tools` will use the ISO 8601 format for dates:  `yyyy-mm-dd`
+
+## Consequences
+
+Dates are displayed in a standard, culture-neutral format.
+
+The UK-style and ISO 8601 formats can be distinguished by their separator
+character.  The UK-style dates used a slash (`/`), while the ISO dates use a
+hyphen (`-`).
+
+Prior to this decision, `adr-tools` was deployed using the UK format for dates.
+After adopting the ISO 8601 format, existing deployments of `adr-tools` must do
+one of the following:
+
+ * Accept mixed formatting of dates within their documentation library.
+ * Update existing documents to use ISO 8601 dates.
+ * Add `ADR_DATE=$(date +%d/%m/%Y)` to `config.sh` to override the new default
+   and continue using UK-style dates.

--- a/src/adr-new
+++ b/src/adr-new
@@ -76,7 +76,7 @@ fi
 newid=$(printf "%04d" $newnum)
 slug=$(echo -n $title | tr -Ccs [:alnum:] - | tr [:upper:] [:lower:] | sed -e 's/[^[:alnum:]]*$//' -e 's/^[^[:alnum:]]*//')
 dstfile=$dstdir/$newid-$slug.md
-date=${ADR_DATE:-$(date +%d/%m/%Y)}
+date=${ADR_DATE:-$(date +%F)}
 
 if [ ! -z $superceded ]
 then


### PR DESCRIPTION
See doc\adr\0007-use-iso-8601-date-format.md for more information about
this change.

Resolves npryce/adr-tools/issues/14