### PR TITLE
Reference adr-tools in ADR generated by init

### DIFF
--- a/src/init.md
+++ b/src/init.md
@@ -16,4 +16,4 @@ We will use Architecture Decision Records, as described by Michael Nygard in thi
 
 ## Consequences
 
-See Michael Nygard's article, linked above.
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's _adr-tools_ at https://github.com/npryce/adr-tools.

--- a/tests/init-adr-repository.expected
+++ b/tests/init-adr-repository.expected
@@ -21,4 +21,4 @@ We will use Architecture Decision Records, as described by Michael Nygard in thi
 
 ## Consequences
 
-See Michael Nygard's article, linked above.
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's _adr-tools_ at https://github.com/npryce/adr-tools.


### PR DESCRIPTION
If someone stumbles upon the doc/adr directory, it's probably a good idea to let her know that there is a command-line tool to manage it.