### PR TITLE
Update INSTALL.md to use official homebrew package

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,10 +8,7 @@ MacOS X
 
 Mac OS X users can install with [Homebrew](https://brew.sh):
 
-    brew install olleolleolle/adr-tools/adr_tools
-    
-Thanks to [Olle Jonsson](https://github.com/olleolleolle).
-
+    brew install adr-tools
 
 From a Release Package
 ----------------------


### PR DESCRIPTION
I got `adr-tools` accepted into the [official homebrew](https://github.com/Homebrew/homebrew-core/pull/13081). So we can update the installation instructions to reflect this now.

Closes #24