### PR TITLE
fixing typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ ADRs are stored in your project as Markdown files in the `doc/adr` directory.
     editor of choice (as specified by the VISUAL or EDITOR environment
     variable).
 
-    To create a new ADR that supercedes a previous one (ADR 9, for example),
+    To create a new ADR that supersedes a previous one (ADR 9, for example),
     use the -s option.
 
         adr new -s 9 Use Rust for performance-critical functionality
 
-    This will create a new ADR file that is flagged as superceding
+    This will create a new ADR file that is flagged as superseding
     ADR 9, and changes the status of ADR 9 to indicate that it is
-    superceded by the new ADR.  It then opens the new ADR in your
+    superseded by the new ADR.  It then opens the new ADR in your
     editor of choice.
     
 3. For further information, use the built in help:

--- a/doc/adr/0004-markdown-format.md
+++ b/doc/adr/0004-markdown-format.md
@@ -13,7 +13,7 @@ The decision records must be stored in a plain text format:
 * This works well with version control systems.
 
 * It allows the tool to modify the status of records and insert
-  hyperlinks when one decision supercedes another.
+  hyperlinks when one decision supersedes another.
 
 * Decisions can be read in the terminal, IDE, version control
   browser, etc.

--- a/src/adr-new
+++ b/src/adr-new
@@ -2,7 +2,7 @@
 set -e
 eval "$($(dirname $0)/adr-config)"
 
-## usage: adr new [-s SUPERCEDED] [-l TARGET:LINK:REVERSE-LINK] TITLE_TEXT...
+## usage: adr new [-s SUPERSEDED] [-l TARGET:LINK:REVERSE-LINK] TITLE_TEXT...
 ##
 ## Creates a new, numbered ADR.  The TITLE_TEXT arguments are concatenated to
 ## form the title of the new ADR.  The ADR is opened for editing in the
@@ -13,44 +13,44 @@ eval "$($(dirname $0)/adr-config)"
 ##
 ## Options:
 ##
-## -s SUPERCEDED   A reference (number or partial filename) of a previous
-##                 decision that the new decision supercedes. A Markdown link
-##                 to the superceded ADR is inserted into the Status section.
-##                 The status of the superceded ADR is changed to record that
-##                 it has been superceded by the new ADR.
+## -s SUPERSEDED   A reference (number or partial filename) of a previous
+##                 decision that the new decision supersedes. A Markdown link
+##                 to the superseded ADR is inserted into the Status section.
+##                 The status of the superseded ADR is changed to record that
+##                 it has been superseded by the new ADR.
 ##
 ## -l TARGET:LINK:REVERSE-LINK
-##                 Links the new ADR to a previous ADR.  
-##                 TARGET is a reference (number or partial filename) of a 
-##                 previous decision. 
+##                 Links the new ADR to a previous ADR.
+##                 TARGET is a reference (number or partial filename) of a
+##                 previous decision.
 ##                 LINK is the description of the link created in the new ADR.
 ##                 REVERSE-LINK is the description of the link created in the
 ##                 existing ADR that will refer to the new ADR.
 ##
-## Multiple -s and -l options can be given, so that the new ADR can supercede 
+## Multiple -s and -l options can be given, so that the new ADR can supersede
 ## or link to multiple existing ADRs.
 ##
 ## E.g. to create a new ADR with the title "Use MySQL Database":
 ##
 ##     adr new Use MySQL Database
 ##
-## E.g. to create a new ADR that supercedes ADR 12:
+## E.g. to create a new ADR that supersedes ADR 12:
 ##
 ##     adr new -s 12 Use PostgreSQL Database
 ##
-## E.g. to create a new ADR that supercedes ADRs 3 and 4, and amends ADR 5:
+## E.g. to create a new ADR that supersedes ADRs 3 and 4, and amends ADR 5:
 ##
 ##     adr new -s 3 -s 4 -l "5:Amends:Amended by" Use Riak CRDTs to cope with scale
 ##
 
-superceded=()
+superseded=()
 links=()
 
 while getopts s:l: arg
 do
     case "$arg" in
         s)
-            superceded+=("$OPTARG")
+            superseded+=("$OPTARG")
             ;;
 		l)
 			links+=("$OPTARG")
@@ -106,11 +106,11 @@ cat $template | sed \
     -e "s|STATUS|Accepted|" \
     > $dstfile
 
-for target in "${superceded[@]}"
+for target in "${superseded[@]}"
 do
-	"$adr_bin_dir/_adr_add_link" "$target" "Superceded by" "$dstfile"
+	"$adr_bin_dir/_adr_add_link" "$target" "Superseded by" "$dstfile"
 	"$adr_bin_dir/_adr_remove_status" "Accepted" "$target"
-	"$adr_bin_dir/_adr_add_link" "$dstfile" "Supercedes" "$target"
+	"$adr_bin_dir/_adr_add_link" "$dstfile" "Supersedes" "$target"
 done
 
 for l in "${links[@]}"
@@ -118,7 +118,7 @@ do
 	target="$(echo $l | cut -d : -f 1)"
 	forward_link="$(echo $l | cut -d : -f 2)"
 	reverse_link="$(echo $l | cut -d : -f 3)"
-	
+
 	"$adr_bin_dir/_adr_add_link" "$dstfile" "$forward_link" "$target"
 	"$adr_bin_dir/_adr_add_link" "$target" "$reverse_link" "$dstfile"
 done

--- a/tests/generate-graph.expected
+++ b/tests/generate-graph.expected
@@ -15,16 +15,16 @@ digraph {
   _1 [label="1. Record architecture decisions"; URL="0001-record-architecture-decisions.html"]
   _2 [label="2. An idea that seems good at the time"; URL="0002-an-idea-that-seems-good-at-the-time.html"]
   _1 -> _2 [style="dotted"];
-  _2 -> _3 [label="Superceded by"]
+  _2 -> _3 [label="Superseded by"]
   _3 [label="3. A better idea"; URL="0003-a-better-idea.html"]
   _2 -> _3 [style="dotted"];
-  _3 -> _2 [label="Supercedes"]
-  _3 -> _5 [label="Superceded by"]
+  _3 -> _2 [label="Supersedes"]
+  _3 -> _5 [label="Superseded by"]
   _4 [label="4. This will work"; URL="0004-this-will-work.html"]
   _3 -> _4 [style="dotted"];
   _5 [label="5. The end"; URL="0005-the-end.html"]
   _4 -> _5 [style="dotted"];
-  _5 -> _3 [label="Supercedes"]
+  _5 -> _3 [label="Supersedes"]
 }
 # with specified extension in links
 adr generate graph -e .xxx
@@ -33,14 +33,14 @@ digraph {
   _1 [label="1. Record architecture decisions"; URL="0001-record-architecture-decisions.xxx"]
   _2 [label="2. An idea that seems good at the time"; URL="0002-an-idea-that-seems-good-at-the-time.xxx"]
   _1 -> _2 [style="dotted"];
-  _2 -> _3 [label="Superceded by"]
+  _2 -> _3 [label="Superseded by"]
   _3 [label="3. A better idea"; URL="0003-a-better-idea.xxx"]
   _2 -> _3 [style="dotted"];
-  _3 -> _2 [label="Supercedes"]
-  _3 -> _5 [label="Superceded by"]
+  _3 -> _2 [label="Supersedes"]
+  _3 -> _5 [label="Superseded by"]
   _4 [label="4. This will work"; URL="0004-this-will-work.xxx"]
   _3 -> _4 [style="dotted"];
   _5 [label="5. The end"; URL="0005-the-end.xxx"]
   _4 -> _5 [style="dotted"];
-  _5 -> _3 [label="Supercedes"]
+  _5 -> _3 [label="Supersedes"]
 }

--- a/tests/supercede-existing-adr.expected
+++ b/tests/supercede-existing-adr.expected
@@ -9,7 +9,7 @@ Date: 1992-01-12
 
 ## Status
 
-Superceded by [2. Second Record](0002-second-record.md)
+Superseded by [2. Second Record](0002-second-record.md)
 
 ## Context
 
@@ -22,7 +22,7 @@ Date: 1992-01-12
 
 Accepted
 
-Supercedes [1. First Record](0001-first-record.md)
+Supersedes [1. First Record](0001-first-record.md)
 
 ## Context
 

--- a/tests/supercede-multiple-adrs.expected
+++ b/tests/supercede-multiple-adrs.expected
@@ -11,7 +11,7 @@ Date: 1992-01-12
 
 ## Status
 
-Superceded by [3. Third Record](0003-third-record.md)
+Superseded by [3. Third Record](0003-third-record.md)
 
 head -8 doc/adr/0002-second-record.md
 # 2. Second Record
@@ -20,7 +20,7 @@ Date: 1992-01-12
 
 ## Status
 
-Superceded by [3. Third Record](0003-third-record.md)
+Superseded by [3. Third Record](0003-third-record.md)
 
 head -12 doc/adr/0003-third-record.md
 # 3. Third Record
@@ -31,7 +31,7 @@ Date: 1992-01-12
 
 Accepted
 
-Supercedes [1. First Record](0001-first-record.md)
+Supersedes [1. First Record](0001-first-record.md)
 
-Supercedes [2. Second Record](0002-second-record.md)
+Supersedes [2. Second Record](0002-second-record.md)
 


### PR DESCRIPTION
I noticed that supersedes was spelt supercedes in my latest ADR. figured I'd put in a pull request to fix that.