### PR TITLE
add autocompletion to adr

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,3 +33,8 @@ Windows 10
 ----------
 The scripts work in the Bash on Ubuntu on Windows, the Linux-subsystem that offically supports Linux command line tools.
 Make sure that you have [installed](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) the Linux-subsystem, run 'bash' on the command line and follow the instructions in the "From a Release Package" section above.
+
+
+Aucomplete
+----------
+In order to have autocomplete on the commands, add the `autocomplete/adr` script to your `/etc/bash_autocomplete.d` or the equivalent to your platform.

--- a/autocomplete/adr
+++ b/autocomplete/adr
@@ -1,0 +1,11 @@
+_adr() {
+  local cur
+  cur=${COMP_WORDS[$COMP_CWORD]}
+
+  local cmd
+  cmd=( ${COMP_WORDS[@]} )
+
+  COMPREPLY=( $(_adr_autocomplete ${COMP_WORDS[*]} ) )
+}
+
+complete -F _adr -o default adr

--- a/autocomplete/adr
+++ b/autocomplete/adr
@@ -1,10 +1,4 @@
 _adr() {
-  local cur
-  cur=${COMP_WORDS[$COMP_CWORD]}
-
-  local cmd
-  cmd=( ${COMP_WORDS[@]} )
-
   COMPREPLY=( $(_adr_autocomplete ${COMP_WORDS[*]} ) )
 }
 

--- a/autocomplete/adr
+++ b/autocomplete/adr
@@ -1,5 +1,9 @@
 _adr() {
-  COMPREPLY=( $(_adr_autocomplete ${COMP_WORDS[*]} ) )
+  # Autocomplete only when entering the last term
+  if [ ${COMP_CWORD} -eq $((${#COMP_WORDS[@]} - 1)) ]
+  then
+    COMPREPLY=( $(_adr_autocomplete ${COMP_WORDS[*]} ) )
+  fi
 }
 
 complete -F _adr -o default adr

--- a/src/_adr_autocomplete
+++ b/src/_adr_autocomplete
@@ -1,0 +1,30 @@
+#!/bin/bash
+eval "$($(dirname $0)/adr-config)"
+
+cmds=("$@")
+available_commands=$( $adr_bin_dir/_adr_commands )
+
+if (( ${#@} <= 2))
+then
+  suggestions=($( compgen -W "${available_commands}" -- "$2" ))
+  if [ "$suggestions" != "$2" ]
+  then
+    echo "${suggestions[*]}"
+    exit 0
+  fi
+fi
+
+subcmds_files=( $(compgen -G "$adr_bin_dir/_adr_$2_"'*') )
+if (( ${#subcmds_files} > 0 ))
+then
+  subcmds=$( for f in "${subcmds_files[@]}"
+  do
+    basename $f | cut -c $(( ${#2} + 7 ))-
+  done )
+  suggestions=($( compgen -W "${subcmds}" -- "$3" ))
+  if [ "$suggestions" != "$3" ]
+  then
+    echo "${suggestions[*]}"
+    exit 0
+  fi
+fi

--- a/src/_adr_autocomplete
+++ b/src/_adr_autocomplete
@@ -2,7 +2,7 @@
 eval "$($(dirname $0)/adr-config)"
 
 cmds=("$@")
-available_commands=$( $adr_bin_dir/_adr_commands )
+available_commands=$( $adr_bin_dir/_adr_commands | sort )
 
 if (( ${#@} <= 2))
 then
@@ -14,7 +14,7 @@ then
   fi
 fi
 
-subcmds_files=( $(compgen -G "$adr_bin_dir/_adr_$2_"'*') )
+subcmds_files=( $(compgen -G "$adr_bin_dir/_adr_$2_"'*' | sort ) )
 if (( ${#subcmds_files} > 0 ))
 then
   subcmds=$( for f in "${subcmds_files[@]}"

--- a/tests/autocomplete.expected
+++ b/tests/autocomplete.expected
@@ -1,9 +1,9 @@
 _adr_autocomplete adr
-init upgrade-repository help list config new generate link
+config generate help init link list new upgrade-repository
 _adr_autocomplete adr li
-list link
+link list
 _adr_autocomplete adr generate
-toc graph
+graph toc
 _adr_autocomplete adr generate to
 toc
 _adr_autocomplete adr ierhir

--- a/tests/autocomplete.expected
+++ b/tests/autocomplete.expected
@@ -1,0 +1,10 @@
+_adr_autocomplete adr
+init upgrade-repository help list config new generate link
+_adr_autocomplete adr li
+list link
+_adr_autocomplete adr generate
+toc graph
+_adr_autocomplete adr generate to
+toc
+_adr_autocomplete adr ierhir
+

--- a/tests/autocomplete.sh
+++ b/tests/autocomplete.sh
@@ -1,0 +1,5 @@
+_adr_autocomplete adr
+_adr_autocomplete adr li
+_adr_autocomplete adr generate
+_adr_autocomplete adr generate to
+_adr_autocomplete adr ierhir


### PR DESCRIPTION
I implemented a simple autocompletion utility as suggested in #22.

I'm not proficient at bash, so there might be some more elegant way of writing it. I'm open to any suggestion to improve the PR.

The current implementation is built to autocomplete the last term of the input.

I have tested with my own configuration only: bash v4.3 on linux (ubuntu xenial). I can't say if something needs to be implemented for other platforms.