### PR TITLE
Add alternative ADR formats to consequences

### DIFF
--- a/doc/adr/0001-record-architecture-decisions.md
+++ b/doc/adr/0001-record-architecture-decisions.md
@@ -17,3 +17,7 @@ We will use Architecture Decision Records, as described by Michael Nygard in thi
 ## Consequences
 
 See Michael Nygard's article, linked above.
+We accept the drawbacks that
+(i) it is not enforced that a justification is stated and
+(ii) it is not enforced that considered other options are listed.
+In other templates such as the [Y-Statements](https://www.infoq.com/articles/sustainable-architectural-design-decisions) or [MADR](https://adr.github.io/madr/), these drawbacks are not present.


### PR DESCRIPTION
For really sustainable architectural decision records, I believe, that considered options should be listed. As far as I understood the template, listing them is not enforced. Further, the justification of the chosen option is not enforced either. I think, these drawbacks (in case they can be regarded as drawback) should be listed in ADR-0001.