### PR TITLE
Support executing through symlink

### DIFF
--- a/src/adr
+++ b/src/adr
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$($(dirname "$(readlink -f $0)")/adr-config)"
 
 cmd=$adr_bin_dir/adr-$1
 


### PR DESCRIPTION
If $0 is a symlinked file, the original did not work (it tried to read config file from the directory where the symlink is).
This fixes that issue by following a possible symlink to where the executable actually is and read config file from there.
Solution based on https://unix.stackexchange.com/a/17500

Just noticed that `readlink -f` is not supported on all operating systems, so might need to consider some improvements...
https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac