### PR TITLE
Add "git bash" to Windows installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,6 +10,7 @@ Mac OS X users can install with [Homebrew](https://brew.sh):
 
     brew install adr-tools
 
+
 From a Release Package
 ----------------------
 
@@ -31,9 +32,20 @@ You can install with Git, if you want to be on the bleeding edge:
 
 Windows 10
 ----------
-The scripts work in the Bash on Ubuntu on Windows, the Linux-subsystem that offically supports Linux command line tools.
-Make sure that you have [installed](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) the Linux-subsystem, run 'bash' on the command line and follow the instructions in the "From a Release Package" section above.
 
+### Git for Windows: git bash
+
+When using git bash within [Git for Windows](https://git-for-windows.github.io/), the scripts can simply be put in `usr\bin` in the installation directory.
+That directory usually is `C:\Program Files\Git\usr\bin`.
+
+1. Download a zip package from the [releases page](https://github.com/npryce/adr-tools/releases)
+2. Unzip the package
+3. Copy everything from `src/` into `C:\Program Files\Git\usr\bin`
+
+### Linux subsystem
+
+The scripts work in the Bash on [Ubuntu on Windows](https://www.microsoft.com/store/p/ubuntu/9nblggh4msv6), the Linux-subsystem that officially supports Linux command line tools.
+Make sure that you have [installed](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) the Linux-subsystem, run `bash` on the command line and follow the instructions in the "From a Release Package" section above.
 
 Autocomplete
 ----------


### PR DESCRIPTION
This adds "git bash" to Windows installation instructions.

Furthermore, this PR refines the "Linux subsystem" section slightly:

- link to "Ubuntu on Windows"
- enhance markdown
- fix typo