### PR TITLE
Add MADR support

### DIFF
--- a/src/_adr_add_link_madr
+++ b/src/_adr_add_link_madr
@@ -1,26 +1,23 @@
 #!/bin/bash
 set -e
 eval "$($(dirname $0)/adr-config)"
-
+date=${ADR_DATE:-$(date +%Y-%m-%d)}
 source=$("$adr_bin_dir/_adr_file" "${1:?SOURCE}")
 link_type="${2:?LINK TYPE}"
 target=$("$adr_bin_dir/_adr_file" "${3:?TARGET}")
 
 target_title="$("$adr_bin_dir/_adr_title" "$target")"
-
-awk -v link_type="$link_type" -v target="$(basename $target)" -v target_title="$target_title" '
+updated_status="| $date | $link_type [$target_title]($(basename $target)) |"
+awk -v updated_status="$updated_status" '
 	BEGIN { 
 		in_status_section=0
 	}
-	/^##/ {
-		if (in_status_section) {
-		    print link_type " ["target_title"](" target ")"
-			print ""
-		}
-		in_status_section=0
+	/^\|.*\|$/ {
+        in_status_section=1
 	}
-	/^## Status$/ { 
-		in_status_section=1 
+	in_status_section && /^\s*$/ {
+        print updated_status
+		in_status_section=0 
 	}
 	{ print }
 ' "$source" > "$source.tmp"

--- a/src/_adr_add_link_madr
+++ b/src/_adr_add_link_madr
@@ -7,19 +7,26 @@ link_type="${2:?LINK TYPE}"
 target=$("$adr_bin_dir/_adr_file" "${3:?TARGET}")
 
 target_title="$("$adr_bin_dir/_adr_title" "$target")"
-updated_status="| $date | $link_type [$target_title]($(basename $target)) |"
-awk -v updated_status="$updated_status" '
-	BEGIN { 
-		in_status_section=0
-	}
-	/^\|.*\|$/ {
-        in_status_section=1
-	}
-	in_status_section && /^\s*$/ {
-        print updated_status
-		in_status_section=0 
-	}
-	{ print }
-' "$source" > "$source.tmp"
+updated_status="$link_type [$target_title]($(basename $target))"
 
-mv "$source.tmp" "$source"
+if [ "$link_type" != "Supercedes" ] 
+then
+awk -v n=3 -v s="* Status: $updated_status" '(NR==n) { print s }{ print } ' "$source" > "$source.tmp" && mv "$source.tmp" "$source"
+fi
+
+if [ "$link_type" == "Superceded by" ]
+then
+sed -e "s/\* Date:.*/\* Date: $date/" "$source" > "$source.tmp" && mv "$source.tmp" "$source"
+fi
+
+if grep -q "## Links" "$source"; then
+    cat <<EOT >> "$source"
+* $updated_status
+EOT
+else
+    cat <<EOT >> "$source"
+## Links
+
+* $updated_status
+EOT
+fi

--- a/src/_adr_generate_graph
+++ b/src/_adr_generate_graph
@@ -28,7 +28,7 @@ eval "$($(dirname $0)/adr-config)"
 
 
 link_extension=.html
-
+template_type=$("$adr_bin_dir/_adr_type")
 while getopts e: arg
 do
     case "$arg" in
@@ -45,7 +45,7 @@ shift $((OPTIND-1))
 
 
 function index() {
-	basename "$1" | sed -e 's/-.*//' | sed -e 's/^0*//'
+	basename "$1" | sed -e 's/-.*//' | sed -e 's/^0//' | sed -e 's/^0//' | sed -e 's/^0//'
 }
 
 echo "digraph {"
@@ -57,11 +57,23 @@ do
 	title=$("$adr_bin_dir/_adr_title" $f)
 	
 	echo "  _$n [label=\"$title\"; URL=\"$(basename $f .md)${link_extension}\"]"
+    case $template_type in
+    "")
 	if [ $n -gt 1 ]
 	then
 		echo "  _$(($n - 1)) -> _$n [style=\"dotted\"];"
 	fi
 
 	"$adr_bin_dir/_adr_links" "$f" | sed -E -e 's/^([0-9]+)=(.+)$/  _'"$n"' -> _\1 [label="\2"]/'
+    ;;
+    madr)
+	if [ $n -gt 0 ]
+	then
+		echo "  _$(($n - 1)) -> _$n [style=\"dotted\"];"
+	fi
+
+	"$adr_bin_dir/_adr_links" "$f" | sed -E -e 's/^([0-9]+)=(.+)$/  _'"$n"' -> _\1 [label="\2"]/'
+    ;;    
+esac
 done
 echo "}"

--- a/src/_adr_generate_graph
+++ b/src/_adr_generate_graph
@@ -61,7 +61,7 @@ do
 	then
 		echo "  _$(($n - 1)) -> _$n [style=\"dotted\"];"
 	fi
-	
+
 	"$adr_bin_dir/_adr_links" "$f" | sed -E -e 's/^([0-9]+)=(.+)$/  _'"$n"' -> _\1 [label="\2"]/'
 done
 echo "}"

--- a/src/_adr_links
+++ b/src/_adr_links
@@ -2,4 +2,4 @@
 set -e
 eval "$($(dirname $0)/adr-config)"
 
-sed -n -E 's/^(.+) \[.*\]\(0*([1-9][0-9]*).*\)/\2=\1/p' "$("$adr_bin_dir/_adr_file" "$1")"
+sed 's/^| [-0-9]* | //' "$("$adr_bin_dir/_adr_file" "$1")" | sed 's/ |$//'| sed -n -E 's/^([a-zA-Z ]+) \[.*\]\(0*([1-9][0-9]*).*\)/\2=\1/p'  

--- a/src/_adr_links
+++ b/src/_adr_links
@@ -2,4 +2,4 @@
 set -e
 eval "$($(dirname $0)/adr-config)"
 
-sed 's/^| [-0-9]* | //' "$("$adr_bin_dir/_adr_file" "$1")" | sed 's/ |$//'| sed -n -E 's/^([a-zA-Z ]+) \[.*\]\(0*([1-9][0-9]*).*\)/\2=\1/p'  
+sed 's/^\* //' "$("$adr_bin_dir/_adr_file" "$1")" | sed -n '/Status:/!p' | sed -n -E 's/^([a-zA-Z ]+) \[.*\]\(0*([1-9][0-9]*).*\)/\2=\1/p'  

--- a/src/_adr_remove_status_madr
+++ b/src/_adr_remove_status_madr
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+eval "$($(dirname $0)/adr-config)"
+#This is empty because madr doesn't actually remove a status ever, but this dummy is necessary because of how superceding is handled
+
+

--- a/src/_adr_remove_status_madr
+++ b/src/_adr_remove_status_madr
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 eval "$($(dirname $0)/adr-config)"
-#This is empty because madr doesn't actually remove a status ever, but this dummy is necessary because of how superceding is handled
 
-
+current_status=${1:?FROM}
+file=$("$adr_bin_dir/_adr_file" "${2:?FILE}")
+pattern="* Status: $current_status"
+sed -n "/\* Status: $current_status/!p" "$file" > temp && mv temp "$file"

--- a/src/_adr_type
+++ b/src/_adr_type
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+eval "$($(dirname $0)/adr-config)"
+
+if [ -f .adr-type ]
+then
+    cat .adr-type
+fi

--- a/src/adr-init
+++ b/src/adr-init
@@ -2,7 +2,7 @@
 set -e
 eval "$($(dirname $0)/adr-config)"
 
-## usage: adr init [DIRECTORY]
+## usage: adr init [DIRECTORY] [TYPE]
 ## 
 ## Initialises the directory of architecture decision records:
 ## 
@@ -11,6 +11,14 @@ eval "$($(dirname $0)/adr-config)"
 ##    record architectural decisions with ADRs.
 ##
 ## If the DIRECTORY is not given, the ADRs are stored in the directory `doc/adr`.
+##
+## To initialize with a non default template a directory has to be specified.
+## E.g. To use the MADR template and save documentation in the docs directory:
+##      adr init docs madr
+##
+## Currently supported templates:
+##  * madr
+
 
 if [ ! -z $1 ]
 then
@@ -18,5 +26,19 @@ then
     echo "$1" > .adr-dir
 fi
 
-VISUAL=true ADR_TEMPLATE="$adr_template_dir/init.md" \
-      "$adr_bin_dir/adr-new" record-architecture-decisions
+if [ ! -z $2 ]
+then
+    template_type=$2
+    if [ -f "$adr_template_dir/template-$template_type.md" ] && [ -f "$adr_template_dir/init-$template_type.md" ]
+    then
+        echo "$2" > .adr-type
+    else
+        echo "$2 is not a supported type"
+    fi
+    VISUAL=true ADR_TEMPLATE="$adr_template_dir/init-$template_type.md" \
+          "$adr_bin_dir/adr-new" record-architecture-decisions
+else
+    VISUAL=true ADR_TEMPLATE="$adr_template_dir/init.md" \
+          "$adr_bin_dir/adr-new" record-architecture-decisions
+fi
+

--- a/src/adr-link
+++ b/src/adr-link
@@ -18,6 +18,14 @@ source="${1:?SOURCE}"
 forward_link="${2:?LINK}"
 target="${3:?TARGET}"
 reverse_link="${4:?REVERSE-LINK}"
+type=$("$adr_bin_dir/_adr_type")
 
-"$adr_bin_dir/_adr_add_link" "$source" "$forward_link" "$target"
-"$adr_bin_dir/_adr_add_link" "$target" "$reverse_link" "$source"
+if [ -z $type ]
+then
+    type_suffix=""
+else
+    type_suffix="_$type"
+fi
+
+"$adr_bin_dir/_adr_add_link$type_suffix" "$source" "$forward_link" "$target"
+"$adr_bin_dir/_adr_add_link$type_suffix" "$target" "$reverse_link" "$source"

--- a/src/adr-new
+++ b/src/adr-new
@@ -102,26 +102,38 @@ then
     exit 1
 fi
 
+#newnum=0
+
 if [ -d $dstdir ]
 then
-    maxid=$(ls $dstdir | grep -Eo '^[0-9]+' | sed -e 's/^0*//' | sort -rn | head -1)
+filecount=$(ls $dstdir | grep -Eo '^[0-9]+' | wc -l)
+    maxid=$(ls $dstdir | grep -Eo '^[0-9]+' | sed -e 's/^0//' | sed -e 's/^0//'| sed -e 's/^0//' | sort -rn | head -1)
     newnum=$(($maxid + 1))
+    if [ -z $maxid ]
+    then
+    newnum_madr=0
+    else    
+    newnum_madr=$(($maxid + 1))
+fi
 else
     newnum=1
+    newnum_madr=0
 fi
 
-newid=$(printf "%04d" $newnum)
+if [ -z $template_type ]
+then
+    newid=$(printf "%04d" $newnum)    
+else
+    newid=$(printf "%04d" $newnum_madr)
+fi
 slug=$(echo -n $title | tr -Ccs [:alnum:] - | tr [:upper:] [:lower:] | sed -e 's/[^[:alnum:]]*$//' -e 's/^[^[:alnum:]]*//')
 dstfile=$dstdir/$newid-$slug.md
 date=${ADR_DATE:-$(date +%Y-%m-%d)}
-
 mkdir -p $dstdir
-
-type=$("$adr_bin_dir/_adr_type")
 
 tempfile=$dstdir/.tempfile
 
-case $type in
+case $template_type in
     "")
     cat $template | sed \
     -e "s|NUMBER|$newnum|" \
@@ -139,6 +151,7 @@ case $type in
     ;;
 esac
 
+type=$("$adr_bin_dir/_adr_type")
 if [ -z $type ]
 then
     type_suffix=""

--- a/src/adr-new
+++ b/src/adr-new
@@ -130,11 +130,12 @@ case $type in
     -e "s|STATUS|Accepted|" \
     > $dstfile
     ;;
-# Date and Status are not contained in template, but should be added when ADR is created
     madr)
-    cat $template | sed -e "s/\[short title of solved problem and solution\]/$title/" > $tempfile
-    awk -v n=2 -v s="\n| Date | Status |\n| -- | -- |\n| $date | Accepted |" 'NR == n {print s} {print}' $tempfile > $dstfile
-    rm $tempfile
+    cat $template | sed \
+    -e "s/\[short title of solved problem and solution\]/$title/" \
+    -e "s/\* Status: \[accepted | superseeded by \[ADR-0005\](0005-example.md) | deprecated | …\] <!-- optional -->/\* Status: Accepted/" \
+    -e "s/\* Date: \[YYYY-MM-DD when the decision was last updated\] <!-- optional -->/\* Date: $date/" \
+    > $dstfile
     ;;
 esac
 

--- a/src/adr-new
+++ b/src/adr-new
@@ -73,14 +73,25 @@ done
 shift $((OPTIND-1))
 
 dstdir=$("$adr_bin_dir/_adr_dir")
+template_type=$("$adr_bin_dir/_adr_type")
 template="$ADR_TEMPLATE"
 if [ -z $template ]
 then
-    template="$dstdir/templates/template.md"
-    if [ ! -f "$template" ]
+    if [ -d "$dstdir/templates" ]
     then
-        template="$adr_template_dir/template.md"
+        template="$dstdir/templates/template.md"
+    else 
+        template="$dstdir/template.md"
     fi
+        if [ ! -f "$template" ]
+        then
+            if [ -z $template_type ]
+            then
+                template="$adr_template_dir/template.md"
+            else
+                template="$adr_template_dir/template-$template_type.md"        
+            fi
+        fi
 fi
 
 title="$@"
@@ -105,28 +116,50 @@ dstfile=$dstdir/$newid-$slug.md
 date=${ADR_DATE:-$(date +%Y-%m-%d)}
 
 mkdir -p $dstdir
-cat $template | sed \
+
+type=$("$adr_bin_dir/_adr_type")
+
+tempfile=$dstdir/.tempfile
+
+case $type in
+    "")
+    cat $template | sed \
     -e "s|NUMBER|$newnum|" \
     -e "s|TITLE|$title|" \
     -e "s|DATE|$date|" \
     -e "s|STATUS|Accepted|" \
     > $dstfile
+    ;;
+# Date and Status are not contained in template, but should be added when ADR is created
+    madr)
+    cat $template | sed -e "s/\[short title of solved problem and solution\]/$title/" > $tempfile
+    awk -v n=2 -v s="\n| Date | Status |\n| -- | -- |\n| $date | Accepted |" 'NR == n {print s} {print}' $tempfile > $dstfile
+    rm $tempfile
+    ;;
+esac
+
+if [ -z $type ]
+then
+    type_suffix=""
+else
+    type_suffix="_$type"
+fi
 
 for target in "${superceded[@]}"
 do
-	"$adr_bin_dir/_adr_add_link" "$target" "Superceded by" "$dstfile"
-	"$adr_bin_dir/_adr_remove_status" "Accepted" "$target"
-	"$adr_bin_dir/_adr_add_link" "$dstfile" "Supercedes" "$target"
+    "$adr_bin_dir/_adr_add_link$type_suffix" "$target" "Superceded by" "$dstfile"
+    "$adr_bin_dir/_adr_remove_status$type_suffix" "Accepted" "$target"
+    "$adr_bin_dir/_adr_add_link$type_suffix" "$dstfile" "Supercedes" "$target"
 done
 
 for l in "${links[@]}"
 do
-	target="$(echo $l | cut -d : -f 1)"
-	forward_link="$(echo $l | cut -d : -f 2)"
-	reverse_link="$(echo $l | cut -d : -f 3)"
-	
-	"$adr_bin_dir/_adr_add_link" "$dstfile" "$forward_link" "$target"
-	"$adr_bin_dir/_adr_add_link" "$target" "$reverse_link" "$dstfile"
+    target="$(echo $l | cut -d : -f 1)"
+    forward_link="$(echo $l | cut -d : -f 2)"
+    reverse_link="$(echo $l | cut -d : -f 3)"
+
+    "$adr_bin_dir/_adr_add_link$type_suffix" "$dstfile" "$forward_link" "$target"
+    "$adr_bin_dir/_adr_add_link$type_suffix" "$target" "$reverse_link" "$dstfile"
 done
 
 ${VISUAL:-${EDITOR:-true}} $dstfile

--- a/src/init-madr.md
+++ b/src/init-madr.md
@@ -1,0 +1,23 @@
+# Use Markdown Architectural Decision Records
+
+Should we record the architectural decisions made in this project?
+And if we do, how to structure these recordings?
+
+## Considered Alternatives
+
+* [MADR](https://adr.github.io/madr/) - Markdown Architectural Decision Records
+* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) - The first incarnation of the term "ADR". Maintainable by [adr-tools](https://github.com/npryce/adr-tools).
+* [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) - The Y-Statements
+* [DecisionRecord](https://github.com/schubmat/DecisionCapture) - Agile records by [@schubmat](https://github.com/schubmat/)
+* Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
+* No records
+
+## Decision Outcome
+
+* Chosen Alternative: MADR
+* Implicit assumptions should be made explicit.
+  Design documentation is important to enable people understanding the decisions later on.
+  See also [A rational design process: How and why to fake it](https://doi.org/10.1109/TSE.1986.6312940).
+* The MADR template is lean and fits our development style.
+
+<!-- Pros and cons of alternatives straight-forward to elicit and therefore not captured. -->

--- a/src/init-madr.md
+++ b/src/init-madr.md
@@ -7,7 +7,7 @@ Which format and structure should these records follow?
 
 ## Considered Options
 
-* [MADR](https://adr.github.io/madr/) 2.0.3 - The Markdown Architectural Decision Records
+* [MADR](https://adr.github.io/madr/) 2.1.0 - The Markdown Architectural Decision Records
 * [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) - The first incarnation of the term "ADR"
 * [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) - The Y-Statements
 * Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
@@ -15,11 +15,11 @@ Which format and structure should these records follow?
 
 ## Decision Outcome
 
-Chosen option: "MADR 2.0.3", because
+Chosen option: "MADR 2.1.0", because
 * Implicit assumptions should be made explicit.
   Design documentation is important to enable people understanding the decisions later on.
   See also [A rational design process: How and why to fake it](https://doi.org/10.1109/TSE.1986.6312940).
 * The MADR format is lean and fits our development style.
 * The MADR structure is comprehensible and facilitates usage & maintenance.
 * The MADR project is vivid.
-* Version 2.0.3 is the latest one available when starting to document ADRs.
+* Version 2.1.0 is the latest one available when starting to document ADRs.

--- a/src/init-madr.md
+++ b/src/init-madr.md
@@ -1,23 +1,25 @@
 # Use Markdown Architectural Decision Records
 
-Should we record the architectural decisions made in this project?
-And if we do, how to structure these recordings?
+## Context and Problem Statement
 
-## Considered Alternatives
+We want to record architectural decisions made in this project.
+Which format and structure should these records follow?
 
-* [MADR](https://adr.github.io/madr/) - Markdown Architectural Decision Records
-* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) - The first incarnation of the term "ADR". Maintainable by [adr-tools](https://github.com/npryce/adr-tools).
+## Considered Options
+
+* [MADR](https://adr.github.io/madr/) 2.0.3 - The Markdown Architectural Decision Records
+* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) - The first incarnation of the term "ADR"
 * [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) - The Y-Statements
-* [DecisionRecord](https://github.com/schubmat/DecisionCapture) - Agile records by [@schubmat](https://github.com/schubmat/)
 * Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
-* No records
+* Formless - No conventions for file format and structure
 
 ## Decision Outcome
 
-* Chosen Alternative: MADR
+Chosen option: "MADR 2.0.3", because
 * Implicit assumptions should be made explicit.
   Design documentation is important to enable people understanding the decisions later on.
   See also [A rational design process: How and why to fake it](https://doi.org/10.1109/TSE.1986.6312940).
-* The MADR template is lean and fits our development style.
-
-<!-- Pros and cons of alternatives straight-forward to elicit and therefore not captured. -->
+* The MADR format is lean and fits our development style.
+* The MADR structure is comprehensible and facilitates usage & maintenance.
+* The MADR project is vivid.
+* Version 2.0.3 is the latest one available when starting to document ADRs.

--- a/src/template-madr.md
+++ b/src/template-madr.md
@@ -1,48 +1,70 @@
 # [short title of solved problem and solution]
 
-User Story: [ticket/issue-number] <!-- optional -->
+* Status: [accepted | superseeded by [ADR-0005](0005-example.md) | deprecated | …] <!-- optional -->
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
 
-[context and problem statement]
-[decision drivers | forces | facing] <!-- optional -->
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
 
 ## Considered Options
 
 * [option 1]
 * [option 2]
 * [option 3]
-* ... <!-- numbers of options can vary -->
+* … <!-- numbers of options can vary -->
 
 ## Decision Outcome
 
-Chosen option: [option 1], because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | ... | comes out best (see below)].
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
 
 Positive Consequences: <!-- optional -->
-  - [e.g., improvement of quality attribute satisfaction, follow-up decisions required, ...]
-  - ...
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
 
 Negative consequences: <!-- optional -->
-  - [e.g., compromising quality attribute, follow-up decisions required, ...]
-  - ...
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
 
 ## Pros and Cons of the Options <!-- optional -->
 
 ### [option 1]
 
+[example | description | pointer to more information | …] <!-- optional -->
+
 * Good, because [argument a]
 * Good, because [argument b]
 * Bad, because [argument c]
-* ... <!-- numbers of pros and cons can vary -->
+* … <!-- numbers of pros and cons can vary -->
 
 ### [option 2]
 
+[example | description | pointer to more information | …] <!-- optional -->
+
 * Good, because [argument a]
 * Good, because [argument b]
 * Bad, because [argument c]
-* ... <!-- numbers of pros and cons can vary -->
+* … <!-- numbers of pros and cons can vary -->
 
 ### [option 3]
 
+[example | description | pointer to more information | …] <!-- optional -->
+
 * Good, because [argument a]
 * Good, because [argument b]
 * Bad, because [argument c]
-* ... <!-- numbers of pros and cons can vary -->
+* … <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->

--- a/src/template-madr.md
+++ b/src/template-madr.md
@@ -1,0 +1,48 @@
+# [short title of solved problem and solution]
+
+User Story: [ticket/issue-number] <!-- optional -->
+
+[context and problem statement]
+[decision drivers | forces | facing] <!-- optional -->
+
+## Considered Options
+
+* [option 1]
+* [option 2]
+* [option 3]
+* ... <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: [option 1], because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | ... | comes out best (see below)].
+
+Positive Consequences: <!-- optional -->
+  - [e.g., improvement of quality attribute satisfaction, follow-up decisions required, ...]
+  - ...
+
+Negative consequences: <!-- optional -->
+  - [e.g., compromising quality attribute, follow-up decisions required, ...]
+  - ...
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* ... <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* ... <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* ... <!-- numbers of pros and cons can vary -->

--- a/src/template-madr.md
+++ b/src/template-madr.md
@@ -27,11 +27,13 @@ Technical Story: [description | ticket/issue URL] <!-- optional -->
 
 Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
 
-Positive Consequences: <!-- optional -->
+### Positive Consequences: <!-- optional -->
+
 * [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
 * …
 
-Negative consequences: <!-- optional -->
+### Negative consequences: <!-- optional -->
+
 * [e.g., compromising quality attribute, follow-up decisions required, …]
 * …
 

--- a/tests/create-first-record-madr.expected
+++ b/tests/create-first-record-madr.expected
@@ -1,0 +1,57 @@
+adr init docs madr
+docs/0001-record-architecture-decisions.md
+adr new The First Decision
+docs/0002-the-first-decision.md
+cat docs/0002-the-first-decision.md
+# The First Decision
+
+| Date | Status |
+| -- | -- |
+| 1992-01-12 | Accepted |
+
+User Story: [ticket/issue-number] <!-- optional -->
+
+[context and problem statement]
+[decision drivers | forces | facing] <!-- optional -->
+
+## Considered Options
+
+* [option 1]
+* [option 2]
+* [option 3]
+* ... <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: [option 1], because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | ... | comes out best (see below)].
+
+Positive Consequences: <!-- optional -->
+  - [e.g., improvement of quality attribute satisfaction, follow-up decisions required, ...]
+  - ...
+
+Negative consequences: <!-- optional -->
+  - [e.g., compromising quality attribute, follow-up decisions required, ...]
+  - ...
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* ... <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* ... <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* ... <!-- numbers of pros and cons can vary -->

--- a/tests/create-first-record-madr.expected
+++ b/tests/create-first-record-madr.expected
@@ -1,8 +1,8 @@
 adr init docs madr
-docs/0001-record-architecture-decisions.md
+docs/0000-record-architecture-decisions.md
 adr new The First Decision
-docs/0002-the-first-decision.md
-cat docs/0002-the-first-decision.md
+docs/0001-the-first-decision.md
+cat docs/0001-the-first-decision.md
 # The First Decision
 
 * Status: Accepted
@@ -32,11 +32,13 @@ Technical Story: [description | ticket/issue URL] <!-- optional -->
 
 Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
 
-Positive Consequences: <!-- optional -->
+### Positive Consequences: <!-- optional -->
+
 * [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
 * …
 
-Negative consequences: <!-- optional -->
+### Negative consequences: <!-- optional -->
+
 * [e.g., compromising quality attribute, follow-up decisions required, …]
 * …
 

--- a/tests/create-first-record-madr.expected
+++ b/tests/create-first-record-madr.expected
@@ -5,53 +5,71 @@ docs/0002-the-first-decision.md
 cat docs/0002-the-first-decision.md
 # The First Decision
 
-| Date | Status |
-| -- | -- |
-| 1992-01-12 | Accepted |
+* Status: Accepted
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: 1992-01-12
 
-User Story: [ticket/issue-number] <!-- optional -->
+Technical Story: [description | ticket/issue URL] <!-- optional -->
 
-[context and problem statement]
-[decision drivers | forces | facing] <!-- optional -->
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
 
 ## Considered Options
 
 * [option 1]
 * [option 2]
 * [option 3]
-* ... <!-- numbers of options can vary -->
+* … <!-- numbers of options can vary -->
 
 ## Decision Outcome
 
-Chosen option: [option 1], because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | ... | comes out best (see below)].
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
 
 Positive Consequences: <!-- optional -->
-  - [e.g., improvement of quality attribute satisfaction, follow-up decisions required, ...]
-  - ...
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
 
 Negative consequences: <!-- optional -->
-  - [e.g., compromising quality attribute, follow-up decisions required, ...]
-  - ...
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
 
 ## Pros and Cons of the Options <!-- optional -->
 
 ### [option 1]
 
+[example | description | pointer to more information | …] <!-- optional -->
+
 * Good, because [argument a]
 * Good, because [argument b]
 * Bad, because [argument c]
-* ... <!-- numbers of pros and cons can vary -->
+* … <!-- numbers of pros and cons can vary -->
 
 ### [option 2]
 
+[example | description | pointer to more information | …] <!-- optional -->
+
 * Good, because [argument a]
 * Good, because [argument b]
 * Bad, because [argument c]
-* ... <!-- numbers of pros and cons can vary -->
+* … <!-- numbers of pros and cons can vary -->
 
 ### [option 3]
 
+[example | description | pointer to more information | …] <!-- optional -->
+
 * Good, because [argument a]
 * Good, because [argument b]
 * Bad, because [argument c]
-* ... <!-- numbers of pros and cons can vary -->
+* … <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->

--- a/tests/create-first-record-madr.sh
+++ b/tests/create-first-record-madr.sh
@@ -1,3 +1,3 @@
 adr init docs madr
 adr new The First Decision
-cat docs/0002-the-first-decision.md
+cat docs/0001-the-first-decision.md

--- a/tests/create-first-record-madr.sh
+++ b/tests/create-first-record-madr.sh
@@ -1,0 +1,3 @@
+adr init docs madr
+adr new The First Decision
+cat docs/0002-the-first-decision.md

--- a/tests/create-multiple-records-madr.expected
+++ b/tests/create-multiple-records-madr.expected
@@ -1,0 +1,31 @@
+adr init docs madr
+docs/0001-record-architecture-decisions.md
+adr new First Decision
+docs/0002-first-decision.md
+adr new Second Decision
+docs/0003-second-decision.md
+adr new Third Decision
+docs/0004-third-decision.md
+ls docs
+0001-record-architecture-decisions.md
+0002-first-decision.md
+0003-second-decision.md
+0004-third-decision.md
+head -8 docs/0003-second-decision.md
+# Second Decision
+
+| Date | Status |
+| -- | -- |
+| 1992-01-12 | Accepted |
+
+User Story: [ticket/issue-number] <!-- optional -->
+
+head -8 docs/0004-third-decision.md
+# Third Decision
+
+| Date | Status |
+| -- | -- |
+| 1992-01-12 | Accepted |
+
+User Story: [ticket/issue-number] <!-- optional -->
+

--- a/tests/create-multiple-records-madr.expected
+++ b/tests/create-multiple-records-madr.expected
@@ -14,18 +14,18 @@ ls docs
 head -8 docs/0003-second-decision.md
 # Second Decision
 
-| Date | Status |
-| -- | -- |
-| 1992-01-12 | Accepted |
+* Status: Accepted
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: 1992-01-12
 
-User Story: [ticket/issue-number] <!-- optional -->
+Technical Story: [description | ticket/issue URL] <!-- optional -->
 
 head -8 docs/0004-third-decision.md
 # Third Decision
 
-| Date | Status |
-| -- | -- |
-| 1992-01-12 | Accepted |
+* Status: Accepted
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: 1992-01-12
 
-User Story: [ticket/issue-number] <!-- optional -->
+Technical Story: [description | ticket/issue URL] <!-- optional -->
 

--- a/tests/create-multiple-records-madr.expected
+++ b/tests/create-multiple-records-madr.expected
@@ -1,17 +1,17 @@
 adr init docs madr
-docs/0001-record-architecture-decisions.md
+docs/0000-record-architecture-decisions.md
 adr new First Decision
-docs/0002-first-decision.md
+docs/0001-first-decision.md
 adr new Second Decision
-docs/0003-second-decision.md
+docs/0002-second-decision.md
 adr new Third Decision
-docs/0004-third-decision.md
+docs/0003-third-decision.md
 ls docs
-0001-record-architecture-decisions.md
-0002-first-decision.md
-0003-second-decision.md
-0004-third-decision.md
-head -8 docs/0003-second-decision.md
+0000-record-architecture-decisions.md
+0001-first-decision.md
+0002-second-decision.md
+0003-third-decision.md
+head -8 docs/0002-second-decision.md
 # Second Decision
 
 * Status: Accepted
@@ -20,7 +20,7 @@ head -8 docs/0003-second-decision.md
 
 Technical Story: [description | ticket/issue URL] <!-- optional -->
 
-head -8 docs/0004-third-decision.md
+head -8 docs/0003-third-decision.md
 # Third Decision
 
 * Status: Accepted

--- a/tests/create-multiple-records-madr.sh
+++ b/tests/create-multiple-records-madr.sh
@@ -1,0 +1,7 @@
+adr init docs madr
+adr new First Decision
+adr new Second Decision
+adr new Third Decision
+ls docs
+head -8 docs/0003-second-decision.md
+head -8 docs/0004-third-decision.md

--- a/tests/create-multiple-records-madr.sh
+++ b/tests/create-multiple-records-madr.sh
@@ -3,5 +3,5 @@ adr new First Decision
 adr new Second Decision
 adr new Third Decision
 ls docs
-head -8 docs/0003-second-decision.md
-head -8 docs/0004-third-decision.md
+head -8 docs/0002-second-decision.md
+head -8 docs/0003-third-decision.md

--- a/tests/generate-contents-madr.expected
+++ b/tests/generate-contents-madr.expected
@@ -1,12 +1,12 @@
 adr init docs madr
-docs/0001-record-architecture-decisions.md
+docs/0000-record-architecture-decisions.md
 adr new First Decision
-docs/0002-first-decision.md
+docs/0001-first-decision.md
 adr new Second Decision
-docs/0003-second-decision.md
+docs/0002-second-decision.md
 adr generate toc
 # Architecture Decision Records
 
-* [Use Markdown Architectural Decision Records](0001-record-architecture-decisions.md)
-* [First Decision](0002-first-decision.md)
-* [Second Decision](0003-second-decision.md)
+* [Use Markdown Architectural Decision Records](0000-record-architecture-decisions.md)
+* [First Decision](0001-first-decision.md)
+* [Second Decision](0002-second-decision.md)

--- a/tests/generate-contents-madr.expected
+++ b/tests/generate-contents-madr.expected
@@ -1,0 +1,12 @@
+adr init docs madr
+docs/0001-record-architecture-decisions.md
+adr new First Decision
+docs/0002-first-decision.md
+adr new Second Decision
+docs/0003-second-decision.md
+adr generate toc
+# Architecture Decision Records
+
+* [Use Markdown Architectural Decision Records](0001-record-architecture-decisions.md)
+* [First Decision](0002-first-decision.md)
+* [Second Decision](0003-second-decision.md)

--- a/tests/generate-contents-madr.sh
+++ b/tests/generate-contents-madr.sh
@@ -1,0 +1,4 @@
+adr init docs madr
+adr new First Decision
+adr new Second Decision
+adr generate toc

--- a/tests/generate-graph-madr.expected
+++ b/tests/generate-graph-madr.expected
@@ -1,0 +1,46 @@
+adr init docs madr
+docs/0001-record-architecture-decisions.md
+adr new An idea that seems good at the time
+docs/0002-an-idea-that-seems-good-at-the-time.md
+adr new -s 2 A better idea
+docs/0003-a-better-idea.md
+adr new This will work
+docs/0004-this-will-work.md
+adr new -s 3 The end
+docs/0005-the-end.md
+# with default extension in links
+adr generate graph
+digraph {
+  node [shape=plaintext];
+  _1 [label="Use Markdown Architectural Decision Records"; URL="0001-record-architecture-decisions.html"]
+  _2 [label="An idea that seems good at the time"; URL="0002-an-idea-that-seems-good-at-the-time.html"]
+  _1 -> _2 [style="dotted"];
+  _2 -> _3 [label="Superceded by"]
+  _3 [label="A better idea"; URL="0003-a-better-idea.html"]
+  _2 -> _3 [style="dotted"];
+  _3 -> _2 [label="Supercedes"]
+  _3 -> _5 [label="Superceded by"]
+  _4 [label="This will work"; URL="0004-this-will-work.html"]
+  _3 -> _4 [style="dotted"];
+  _5 [label="The end"; URL="0005-the-end.html"]
+  _4 -> _5 [style="dotted"];
+  _5 -> _3 [label="Supercedes"]
+}
+# with specified extension in links
+adr generate graph -e .xxx
+digraph {
+  node [shape=plaintext];
+  _1 [label="Use Markdown Architectural Decision Records"; URL="0001-record-architecture-decisions.xxx"]
+  _2 [label="An idea that seems good at the time"; URL="0002-an-idea-that-seems-good-at-the-time.xxx"]
+  _1 -> _2 [style="dotted"];
+  _2 -> _3 [label="Superceded by"]
+  _3 [label="A better idea"; URL="0003-a-better-idea.xxx"]
+  _2 -> _3 [style="dotted"];
+  _3 -> _2 [label="Supercedes"]
+  _3 -> _5 [label="Superceded by"]
+  _4 [label="This will work"; URL="0004-this-will-work.xxx"]
+  _3 -> _4 [style="dotted"];
+  _5 [label="The end"; URL="0005-the-end.xxx"]
+  _4 -> _5 [style="dotted"];
+  _5 -> _3 [label="Supercedes"]
+}

--- a/tests/generate-graph-madr.expected
+++ b/tests/generate-graph-madr.expected
@@ -1,46 +1,46 @@
 adr init docs madr
-docs/0001-record-architecture-decisions.md
+docs/0000-record-architecture-decisions.md
 adr new An idea that seems good at the time
-docs/0002-an-idea-that-seems-good-at-the-time.md
-adr new -s 2 A better idea
-docs/0003-a-better-idea.md
+docs/0001-an-idea-that-seems-good-at-the-time.md
+adr new -s 1 A better idea
+docs/0002-a-better-idea.md
 adr new This will work
-docs/0004-this-will-work.md
+docs/0003-this-will-work.md
 adr new -s 3 The end
-docs/0005-the-end.md
+docs/0004-the-end.md
 # with default extension in links
 adr generate graph
 digraph {
   node [shape=plaintext];
-  _1 [label="Use Markdown Architectural Decision Records"; URL="0001-record-architecture-decisions.html"]
-  _2 [label="An idea that seems good at the time"; URL="0002-an-idea-that-seems-good-at-the-time.html"]
+  _0 [label="Use Markdown Architectural Decision Records"; URL="0000-record-architecture-decisions.html"]
+  _1 [label="An idea that seems good at the time"; URL="0001-an-idea-that-seems-good-at-the-time.html"]
+  _0 -> _1 [style="dotted"];
+  _1 -> _2 [label="Superceded by"]
+  _2 [label="A better idea"; URL="0002-a-better-idea.html"]
   _1 -> _2 [style="dotted"];
-  _2 -> _3 [label="Superceded by"]
-  _3 [label="A better idea"; URL="0003-a-better-idea.html"]
+  _2 -> _1 [label="Supercedes"]
+  _3 [label="This will work"; URL="0003-this-will-work.html"]
   _2 -> _3 [style="dotted"];
-  _3 -> _2 [label="Supercedes"]
-  _3 -> _5 [label="Superceded by"]
-  _4 [label="This will work"; URL="0004-this-will-work.html"]
+  _3 -> _4 [label="Superceded by"]
+  _4 [label="The end"; URL="0004-the-end.html"]
   _3 -> _4 [style="dotted"];
-  _5 [label="The end"; URL="0005-the-end.html"]
-  _4 -> _5 [style="dotted"];
-  _5 -> _3 [label="Supercedes"]
+  _4 -> _3 [label="Supercedes"]
 }
 # with specified extension in links
 adr generate graph -e .xxx
 digraph {
   node [shape=plaintext];
-  _1 [label="Use Markdown Architectural Decision Records"; URL="0001-record-architecture-decisions.xxx"]
-  _2 [label="An idea that seems good at the time"; URL="0002-an-idea-that-seems-good-at-the-time.xxx"]
+  _0 [label="Use Markdown Architectural Decision Records"; URL="0000-record-architecture-decisions.xxx"]
+  _1 [label="An idea that seems good at the time"; URL="0001-an-idea-that-seems-good-at-the-time.xxx"]
+  _0 -> _1 [style="dotted"];
+  _1 -> _2 [label="Superceded by"]
+  _2 [label="A better idea"; URL="0002-a-better-idea.xxx"]
   _1 -> _2 [style="dotted"];
-  _2 -> _3 [label="Superceded by"]
-  _3 [label="A better idea"; URL="0003-a-better-idea.xxx"]
+  _2 -> _1 [label="Supercedes"]
+  _3 [label="This will work"; URL="0003-this-will-work.xxx"]
   _2 -> _3 [style="dotted"];
-  _3 -> _2 [label="Supercedes"]
-  _3 -> _5 [label="Superceded by"]
-  _4 [label="This will work"; URL="0004-this-will-work.xxx"]
+  _3 -> _4 [label="Superceded by"]
+  _4 [label="The end"; URL="0004-the-end.xxx"]
   _3 -> _4 [style="dotted"];
-  _5 [label="The end"; URL="0005-the-end.xxx"]
-  _4 -> _5 [style="dotted"];
-  _5 -> _3 [label="Supercedes"]
+  _4 -> _3 [label="Supercedes"]
 }

--- a/tests/generate-graph-madr.sh
+++ b/tests/generate-graph-madr.sh
@@ -1,0 +1,9 @@
+adr init docs madr
+adr new An idea that seems good at the time
+adr new -s 2 A better idea
+adr new This will work
+adr new -s 3 The end
+# with default extension in links
+adr generate graph
+# with specified extension in links
+adr generate graph -e .xxx

--- a/tests/generate-graph-madr.sh
+++ b/tests/generate-graph-madr.sh
@@ -1,6 +1,6 @@
 adr init docs madr
 adr new An idea that seems good at the time
-adr new -s 2 A better idea
+adr new -s 1 A better idea
 adr new This will work
 adr new -s 3 The end
 # with default extension in links

--- a/tests/init-repository-madr.expected
+++ b/tests/init-repository-madr.expected
@@ -5,28 +5,26 @@ ls docs
 cat docs/0001-record-architecture-decisions.md
 # Use Markdown Architectural Decision Records
 
-| Date | Status |
-| -- | -- |
-| 1992-01-12 | Accepted |
+## Context and Problem Statement
 
-Should we record the architectural decisions made in this project?
-And if we do, how to structure these recordings?
+We want to record architectural decisions made in this project.
+Which format and structure should these records follow?
 
-## Considered Alternatives
+## Considered Options
 
-* [MADR](https://adr.github.io/madr/) - Markdown Architectural Decision Records
-* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) - The first incarnation of the term "ADR". Maintainable by [adr-tools](https://github.com/npryce/adr-tools).
+* [MADR](https://adr.github.io/madr/) 2.0.3 - The Markdown Architectural Decision Records
+* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) - The first incarnation of the term "ADR"
 * [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) - The Y-Statements
-* [DecisionRecord](https://github.com/schubmat/DecisionCapture) - Agile records by [@schubmat](https://github.com/schubmat/)
 * Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
-* No records
+* Formless - No conventions for file format and structure
 
 ## Decision Outcome
 
-* Chosen Alternative: MADR
+Chosen option: "MADR 2.0.3", because
 * Implicit assumptions should be made explicit.
   Design documentation is important to enable people understanding the decisions later on.
   See also [A rational design process: How and why to fake it](https://doi.org/10.1109/TSE.1986.6312940).
-* The MADR template is lean and fits our development style.
-
-<!-- Pros and cons of alternatives straight-forward to elicit and therefore not captured. -->
+* The MADR format is lean and fits our development style.
+* The MADR structure is comprehensible and facilitates usage & maintenance.
+* The MADR project is vivid.
+* Version 2.0.3 is the latest one available when starting to document ADRs.

--- a/tests/init-repository-madr.expected
+++ b/tests/init-repository-madr.expected
@@ -1,0 +1,32 @@
+adr init docs madr
+docs/0001-record-architecture-decisions.md
+ls docs
+0001-record-architecture-decisions.md
+cat docs/0001-record-architecture-decisions.md
+# Use Markdown Architectural Decision Records
+
+| Date | Status |
+| -- | -- |
+| 1992-01-12 | Accepted |
+
+Should we record the architectural decisions made in this project?
+And if we do, how to structure these recordings?
+
+## Considered Alternatives
+
+* [MADR](https://adr.github.io/madr/) - Markdown Architectural Decision Records
+* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) - The first incarnation of the term "ADR". Maintainable by [adr-tools](https://github.com/npryce/adr-tools).
+* [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) - The Y-Statements
+* [DecisionRecord](https://github.com/schubmat/DecisionCapture) - Agile records by [@schubmat](https://github.com/schubmat/)
+* Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
+* No records
+
+## Decision Outcome
+
+* Chosen Alternative: MADR
+* Implicit assumptions should be made explicit.
+  Design documentation is important to enable people understanding the decisions later on.
+  See also [A rational design process: How and why to fake it](https://doi.org/10.1109/TSE.1986.6312940).
+* The MADR template is lean and fits our development style.
+
+<!-- Pros and cons of alternatives straight-forward to elicit and therefore not captured. -->

--- a/tests/init-repository-madr.expected
+++ b/tests/init-repository-madr.expected
@@ -1,8 +1,8 @@
 adr init docs madr
-docs/0001-record-architecture-decisions.md
+docs/0000-record-architecture-decisions.md
 ls docs
-0001-record-architecture-decisions.md
-cat docs/0001-record-architecture-decisions.md
+0000-record-architecture-decisions.md
+cat docs/0000-record-architecture-decisions.md
 # Use Markdown Architectural Decision Records
 
 ## Context and Problem Statement
@@ -12,7 +12,7 @@ Which format and structure should these records follow?
 
 ## Considered Options
 
-* [MADR](https://adr.github.io/madr/) 2.0.3 - The Markdown Architectural Decision Records
+* [MADR](https://adr.github.io/madr/) 2.1.0 - The Markdown Architectural Decision Records
 * [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) - The first incarnation of the term "ADR"
 * [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) - The Y-Statements
 * Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
@@ -20,11 +20,11 @@ Which format and structure should these records follow?
 
 ## Decision Outcome
 
-Chosen option: "MADR 2.0.3", because
+Chosen option: "MADR 2.1.0", because
 * Implicit assumptions should be made explicit.
   Design documentation is important to enable people understanding the decisions later on.
   See also [A rational design process: How and why to fake it](https://doi.org/10.1109/TSE.1986.6312940).
 * The MADR format is lean and fits our development style.
 * The MADR structure is comprehensible and facilitates usage & maintenance.
 * The MADR project is vivid.
-* Version 2.0.3 is the latest one available when starting to document ADRs.
+* Version 2.1.0 is the latest one available when starting to document ADRs.

--- a/tests/init-repository-madr.sh
+++ b/tests/init-repository-madr.sh
@@ -1,3 +1,3 @@
 adr init docs madr
 ls docs
-cat docs/0001-record-architecture-decisions.md
+cat docs/0000-record-architecture-decisions.md

--- a/tests/init-repository-madr.sh
+++ b/tests/init-repository-madr.sh
@@ -1,0 +1,3 @@
+adr init docs madr
+ls docs
+cat docs/0001-record-architecture-decisions.md

--- a/tests/linking-madr.expected
+++ b/tests/linking-madr.expected
@@ -1,0 +1,51 @@
+adr init docs madr
+docs/0001-record-architecture-decisions.md
+adr new First Record
+docs/0002-first-record.md
+adr new Second Record
+docs/0003-second-record.md
+adr new Third Record
+docs/0004-third-record.md
+adr link 4 Amends 2 "Amended by"
+adr link 4 Clarifies 3 "Clarified by"
+head -12 docs/0002-first-record.md
+# First Record
+
+| Date | Status |
+| -- | -- |
+| 1992-01-12 | Accepted |
+| 1992-01-12 | Amended by [Third Record](0004-third-record.md) |
+
+User Story: [ticket/issue-number] <!-- optional -->
+
+[context and problem statement]
+[decision drivers | forces | facing] <!-- optional -->
+
+head -12 docs/0003-second-record.md
+# Second Record
+
+| Date | Status |
+| -- | -- |
+| 1992-01-12 | Accepted |
+| 1992-01-12 | Clarified by [Third Record](0004-third-record.md) |
+
+User Story: [ticket/issue-number] <!-- optional -->
+
+[context and problem statement]
+[decision drivers | forces | facing] <!-- optional -->
+
+head -14 docs/0004-third-record.md
+# Third Record
+
+| Date | Status |
+| -- | -- |
+| 1992-01-12 | Accepted |
+| 1992-01-12 | Amends [First Record](0002-first-record.md) |
+| 1992-01-12 | Clarifies [Second Record](0003-second-record.md) |
+
+User Story: [ticket/issue-number] <!-- optional -->
+
+[context and problem statement]
+[decision drivers | forces | facing] <!-- optional -->
+
+## Considered Options

--- a/tests/linking-madr.expected
+++ b/tests/linking-madr.expected
@@ -1,29 +1,29 @@
 adr init docs madr
-docs/0001-record-architecture-decisions.md
+docs/0000-record-architecture-decisions.md
 adr new First Record
-docs/0002-first-record.md
+docs/0001-first-record.md
 adr new Second Record
-docs/0003-second-record.md
+docs/0002-second-record.md
 adr new Third Record
-docs/0004-third-record.md
-adr link 4 Amends 2 "Amended by"
-adr link 4 Clarifies 3 "Clarified by"
-tail -5 docs/0002-first-record.md
+docs/0003-third-record.md
+adr link 3 Amends 1 "Amended by"
+adr link 3 Clarifies 2 "Clarified by"
+tail -5 docs/0001-first-record.md
 ## Links <!-- optional -->
 
 * [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
 * … <!-- numbers of links can vary -->
-* Amended by [Third Record](0004-third-record.md)
-tail -5 docs/0003-second-record.md
+* Amended by [Third Record](0003-third-record.md)
+tail -5 docs/0002-second-record.md
 ## Links <!-- optional -->
 
 * [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
 * … <!-- numbers of links can vary -->
-* Clarified by [Third Record](0004-third-record.md)
-tail -6 docs/0004-third-record.md
+* Clarified by [Third Record](0003-third-record.md)
+tail -6 docs/0003-third-record.md
 ## Links <!-- optional -->
 
 * [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
 * … <!-- numbers of links can vary -->
-* Amends [First Record](0002-first-record.md)
-* Clarifies [Second Record](0003-second-record.md)
+* Amends [First Record](0001-first-record.md)
+* Clarifies [Second Record](0002-second-record.md)

--- a/tests/linking-madr.expected
+++ b/tests/linking-madr.expected
@@ -8,44 +8,22 @@ adr new Third Record
 docs/0004-third-record.md
 adr link 4 Amends 2 "Amended by"
 adr link 4 Clarifies 3 "Clarified by"
-head -12 docs/0002-first-record.md
-# First Record
+tail -5 docs/0002-first-record.md
+## Links <!-- optional -->
 
-| Date | Status |
-| -- | -- |
-| 1992-01-12 | Accepted |
-| 1992-01-12 | Amended by [Third Record](0004-third-record.md) |
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->
+* Amended by [Third Record](0004-third-record.md)
+tail -5 docs/0003-second-record.md
+## Links <!-- optional -->
 
-User Story: [ticket/issue-number] <!-- optional -->
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->
+* Clarified by [Third Record](0004-third-record.md)
+tail -6 docs/0004-third-record.md
+## Links <!-- optional -->
 
-[context and problem statement]
-[decision drivers | forces | facing] <!-- optional -->
-
-head -12 docs/0003-second-record.md
-# Second Record
-
-| Date | Status |
-| -- | -- |
-| 1992-01-12 | Accepted |
-| 1992-01-12 | Clarified by [Third Record](0004-third-record.md) |
-
-User Story: [ticket/issue-number] <!-- optional -->
-
-[context and problem statement]
-[decision drivers | forces | facing] <!-- optional -->
-
-head -14 docs/0004-third-record.md
-# Third Record
-
-| Date | Status |
-| -- | -- |
-| 1992-01-12 | Accepted |
-| 1992-01-12 | Amends [First Record](0002-first-record.md) |
-| 1992-01-12 | Clarifies [Second Record](0003-second-record.md) |
-
-User Story: [ticket/issue-number] <!-- optional -->
-
-[context and problem statement]
-[decision drivers | forces | facing] <!-- optional -->
-
-## Considered Options
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->
+* Amends [First Record](0002-first-record.md)
+* Clarifies [Second Record](0003-second-record.md)

--- a/tests/linking-madr.sh
+++ b/tests/linking-madr.sh
@@ -1,0 +1,9 @@
+adr init docs madr
+adr new First Record
+adr new Second Record
+adr new Third Record
+adr link 4 Amends 2 "Amended by"
+adr link 4 Clarifies 3 "Clarified by"
+head -12 docs/0002-first-record.md
+head -12 docs/0003-second-record.md
+head -14 docs/0004-third-record.md

--- a/tests/linking-madr.sh
+++ b/tests/linking-madr.sh
@@ -4,6 +4,6 @@ adr new Second Record
 adr new Third Record
 adr link 4 Amends 2 "Amended by"
 adr link 4 Clarifies 3 "Clarified by"
-head -12 docs/0002-first-record.md
-head -12 docs/0003-second-record.md
-head -14 docs/0004-third-record.md
+tail -5 docs/0002-first-record.md
+tail -5 docs/0003-second-record.md
+tail -6 docs/0004-third-record.md

--- a/tests/linking-madr.sh
+++ b/tests/linking-madr.sh
@@ -2,8 +2,8 @@ adr init docs madr
 adr new First Record
 adr new Second Record
 adr new Third Record
-adr link 4 Amends 2 "Amended by"
-adr link 4 Clarifies 3 "Clarified by"
-tail -5 docs/0002-first-record.md
-tail -5 docs/0003-second-record.md
-tail -6 docs/0004-third-record.md
+adr link 3 Amends 1 "Amended by"
+adr link 3 Clarifies 2 "Clarified by"
+tail -5 docs/0001-first-record.md
+tail -5 docs/0002-second-record.md
+tail -6 docs/0003-third-record.md

--- a/tests/linking-new-records-madr.expected
+++ b/tests/linking-new-records-madr.expected
@@ -1,27 +1,27 @@
 adr init docs madr
-docs/0001-record-architecture-decisions.md
+docs/0000-record-architecture-decisions.md
 adr new First Record
-docs/0002-first-record.md
+docs/0001-first-record.md
 adr new Second Record
-docs/0003-second-record.md
-adr new -l "2:Amends:Amended by" -l "3:Clarifies:Clarified by" Third Record
-docs/0004-third-record.md
-tail -5 docs/0002-first-record.md
+docs/0002-second-record.md
+adr new -l "1:Amends:Amended by" -l "2:Clarifies:Clarified by" Third Record
+docs/0003-third-record.md
+tail -5 docs/0001-first-record.md
 ## Links <!-- optional -->
 
 * [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
 * … <!-- numbers of links can vary -->
-* Amended by [Third Record](0004-third-record.md)
-tail -5 docs/0003-second-record.md
+* Amended by [Third Record](0003-third-record.md)
+tail -5 docs/0002-second-record.md
 ## Links <!-- optional -->
 
 * [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
 * … <!-- numbers of links can vary -->
-* Clarified by [Third Record](0004-third-record.md)
-tail -6 docs/0004-third-record.md
+* Clarified by [Third Record](0003-third-record.md)
+tail -6 docs/0003-third-record.md
 ## Links <!-- optional -->
 
 * [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
 * … <!-- numbers of links can vary -->
-* Amends [First Record](0002-first-record.md)
-* Clarifies [Second Record](0003-second-record.md)
+* Amends [First Record](0001-first-record.md)
+* Clarifies [Second Record](0002-second-record.md)

--- a/tests/linking-new-records-madr.expected
+++ b/tests/linking-new-records-madr.expected
@@ -6,44 +6,22 @@ adr new Second Record
 docs/0003-second-record.md
 adr new -l "2:Amends:Amended by" -l "3:Clarifies:Clarified by" Third Record
 docs/0004-third-record.md
-head -12 docs/0002-first-record.md
-# First Record
+tail -5 docs/0002-first-record.md
+## Links <!-- optional -->
 
-| Date | Status |
-| -- | -- |
-| 1992-01-12 | Accepted |
-| 1992-01-12 | Amended by [Third Record](0004-third-record.md) |
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->
+* Amended by [Third Record](0004-third-record.md)
+tail -5 docs/0003-second-record.md
+## Links <!-- optional -->
 
-User Story: [ticket/issue-number] <!-- optional -->
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->
+* Clarified by [Third Record](0004-third-record.md)
+tail -6 docs/0004-third-record.md
+## Links <!-- optional -->
 
-[context and problem statement]
-[decision drivers | forces | facing] <!-- optional -->
-
-head -12 docs/0003-second-record.md
-# Second Record
-
-| Date | Status |
-| -- | -- |
-| 1992-01-12 | Accepted |
-| 1992-01-12 | Clarified by [Third Record](0004-third-record.md) |
-
-User Story: [ticket/issue-number] <!-- optional -->
-
-[context and problem statement]
-[decision drivers | forces | facing] <!-- optional -->
-
-head -14 docs/0004-third-record.md
-# Third Record
-
-| Date | Status |
-| -- | -- |
-| 1992-01-12 | Accepted |
-| 1992-01-12 | Amends [First Record](0002-first-record.md) |
-| 1992-01-12 | Clarifies [Second Record](0003-second-record.md) |
-
-User Story: [ticket/issue-number] <!-- optional -->
-
-[context and problem statement]
-[decision drivers | forces | facing] <!-- optional -->
-
-## Considered Options
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->
+* Amends [First Record](0002-first-record.md)
+* Clarifies [Second Record](0003-second-record.md)

--- a/tests/linking-new-records-madr.expected
+++ b/tests/linking-new-records-madr.expected
@@ -1,0 +1,49 @@
+adr init docs madr
+docs/0001-record-architecture-decisions.md
+adr new First Record
+docs/0002-first-record.md
+adr new Second Record
+docs/0003-second-record.md
+adr new -l "2:Amends:Amended by" -l "3:Clarifies:Clarified by" Third Record
+docs/0004-third-record.md
+head -12 docs/0002-first-record.md
+# First Record
+
+| Date | Status |
+| -- | -- |
+| 1992-01-12 | Accepted |
+| 1992-01-12 | Amended by [Third Record](0004-third-record.md) |
+
+User Story: [ticket/issue-number] <!-- optional -->
+
+[context and problem statement]
+[decision drivers | forces | facing] <!-- optional -->
+
+head -12 docs/0003-second-record.md
+# Second Record
+
+| Date | Status |
+| -- | -- |
+| 1992-01-12 | Accepted |
+| 1992-01-12 | Clarified by [Third Record](0004-third-record.md) |
+
+User Story: [ticket/issue-number] <!-- optional -->
+
+[context and problem statement]
+[decision drivers | forces | facing] <!-- optional -->
+
+head -14 docs/0004-third-record.md
+# Third Record
+
+| Date | Status |
+| -- | -- |
+| 1992-01-12 | Accepted |
+| 1992-01-12 | Amends [First Record](0002-first-record.md) |
+| 1992-01-12 | Clarifies [Second Record](0003-second-record.md) |
+
+User Story: [ticket/issue-number] <!-- optional -->
+
+[context and problem statement]
+[decision drivers | forces | facing] <!-- optional -->
+
+## Considered Options

--- a/tests/linking-new-records-madr.sh
+++ b/tests/linking-new-records-madr.sh
@@ -2,6 +2,6 @@ adr init docs madr
 adr new First Record
 adr new Second Record
 adr new -l "2:Amends:Amended by" -l "3:Clarifies:Clarified by" Third Record
-head -12 docs/0002-first-record.md
-head -12 docs/0003-second-record.md
-head -14 docs/0004-third-record.md
+tail -5 docs/0002-first-record.md
+tail -5 docs/0003-second-record.md
+tail -6 docs/0004-third-record.md

--- a/tests/linking-new-records-madr.sh
+++ b/tests/linking-new-records-madr.sh
@@ -1,7 +1,7 @@
 adr init docs madr
 adr new First Record
 adr new Second Record
-adr new -l "2:Amends:Amended by" -l "3:Clarifies:Clarified by" Third Record
-tail -5 docs/0002-first-record.md
-tail -5 docs/0003-second-record.md
-tail -6 docs/0004-third-record.md
+adr new -l "1:Amends:Amended by" -l "2:Clarifies:Clarified by" Third Record
+tail -5 docs/0001-first-record.md
+tail -5 docs/0002-second-record.md
+tail -6 docs/0003-third-record.md

--- a/tests/linking-new-records-madr.sh
+++ b/tests/linking-new-records-madr.sh
@@ -1,0 +1,7 @@
+adr init docs madr
+adr new First Record
+adr new Second Record
+adr new -l "2:Amends:Amended by" -l "3:Clarifies:Clarified by" Third Record
+head -12 docs/0002-first-record.md
+head -12 docs/0003-second-record.md
+head -14 docs/0004-third-record.md

--- a/tests/list-records-madr.expected
+++ b/tests/list-records-madr.expected
@@ -1,0 +1,17 @@
+adr list
+The doc/adr directory does not exist
+adr init docs madr
+docs/0001-record-architecture-decisions.md
+adr list
+docs/0001-record-architecture-decisions.md
+adr new first
+docs/0002-first.md
+adr list
+docs/0001-record-architecture-decisions.md
+docs/0002-first.md
+adr new second
+docs/0003-second.md
+adr list
+docs/0001-record-architecture-decisions.md
+docs/0002-first.md
+docs/0003-second.md

--- a/tests/list-records-madr.expected
+++ b/tests/list-records-madr.expected
@@ -1,17 +1,17 @@
 adr list
 The doc/adr directory does not exist
 adr init docs madr
-docs/0001-record-architecture-decisions.md
+docs/0000-record-architecture-decisions.md
 adr list
-docs/0001-record-architecture-decisions.md
+docs/0000-record-architecture-decisions.md
 adr new first
-docs/0002-first.md
+docs/0001-first.md
 adr list
-docs/0001-record-architecture-decisions.md
-docs/0002-first.md
+docs/0000-record-architecture-decisions.md
+docs/0001-first.md
 adr new second
-docs/0003-second.md
+docs/0002-second.md
 adr list
-docs/0001-record-architecture-decisions.md
-docs/0002-first.md
-docs/0003-second.md
+docs/0000-record-architecture-decisions.md
+docs/0001-first.md
+docs/0002-second.md

--- a/tests/list-records-madr.sh
+++ b/tests/list-records-madr.sh
@@ -1,0 +1,7 @@
+adr list
+adr init docs madr
+adr list
+adr new first
+adr list
+adr new second
+adr list

--- a/tests/supercede-existing-adr-madr.expected
+++ b/tests/supercede-existing-adr-madr.expected
@@ -1,13 +1,13 @@
 adr init docs madr
-docs/0001-record-architecture-decisions.md
+docs/0000-record-architecture-decisions.md
 adr new First Record
-docs/0002-first-record.md
-adr new -s 2 Second Record
-docs/0003-second-record.md
-head -10 docs/0002-first-record.md
+docs/0001-first-record.md
+adr new -s 1 Second Record
+docs/0002-second-record.md
+head -10 docs/0001-first-record.md
 # First Record
 
-* Status: Superceded by [Second Record](0003-second-record.md)
+* Status: Superceded by [Second Record](0002-second-record.md)
 * Deciders: [list everyone involved in the decision] <!-- optional -->
 * Date: 1992-01-12
 
@@ -15,9 +15,9 @@ Technical Story: [description | ticket/issue URL] <!-- optional -->
 
 ## Context and Problem Statement
 
-tail -5 docs/0003-second-record.md
+tail -5 docs/0002-second-record.md
 ## Links <!-- optional -->
 
 * [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
 * … <!-- numbers of links can vary -->
-* Supercedes [First Record](0002-first-record.md)
+* Supercedes [First Record](0001-first-record.md)

--- a/tests/supercede-existing-adr-madr.expected
+++ b/tests/supercede-existing-adr-madr.expected
@@ -1,0 +1,30 @@
+adr init docs madr
+docs/0001-record-architecture-decisions.md
+adr new First Record
+docs/0002-first-record.md
+adr new -s 2 Second Record
+docs/0003-second-record.md
+head -10 docs/0002-first-record.md
+# First Record
+
+| Date | Status |
+| -- | -- |
+| 1992-01-12 | Accepted |
+| 1992-01-12 | Superceded by [Second Record](0003-second-record.md) |
+
+User Story: [ticket/issue-number] <!-- optional -->
+
+[context and problem statement]
+head -12 docs/0003-second-record.md
+# Second Record
+
+| Date | Status |
+| -- | -- |
+| 1992-01-12 | Accepted |
+| 1992-01-12 | Supercedes [First Record](0002-first-record.md) |
+
+User Story: [ticket/issue-number] <!-- optional -->
+
+[context and problem statement]
+[decision drivers | forces | facing] <!-- optional -->
+

--- a/tests/supercede-existing-adr-madr.expected
+++ b/tests/supercede-existing-adr-madr.expected
@@ -7,24 +7,17 @@ docs/0003-second-record.md
 head -10 docs/0002-first-record.md
 # First Record
 
-| Date | Status |
-| -- | -- |
-| 1992-01-12 | Accepted |
-| 1992-01-12 | Superceded by [Second Record](0003-second-record.md) |
+* Status: Superceded by [Second Record](0003-second-record.md)
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: 1992-01-12
 
-User Story: [ticket/issue-number] <!-- optional -->
+Technical Story: [description | ticket/issue URL] <!-- optional -->
 
-[context and problem statement]
-head -12 docs/0003-second-record.md
-# Second Record
+## Context and Problem Statement
 
-| Date | Status |
-| -- | -- |
-| 1992-01-12 | Accepted |
-| 1992-01-12 | Supercedes [First Record](0002-first-record.md) |
+tail -5 docs/0003-second-record.md
+## Links <!-- optional -->
 
-User Story: [ticket/issue-number] <!-- optional -->
-
-[context and problem statement]
-[decision drivers | forces | facing] <!-- optional -->
-
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->
+* Supercedes [First Record](0002-first-record.md)

--- a/tests/supercede-existing-adr-madr.sh
+++ b/tests/supercede-existing-adr-madr.sh
@@ -1,5 +1,5 @@
 adr init docs madr
 adr new First Record
-adr new -s 2 Second Record
-head -10 docs/0002-first-record.md
-tail -5 docs/0003-second-record.md
+adr new -s 1 Second Record
+head -10 docs/0001-first-record.md
+tail -5 docs/0002-second-record.md

--- a/tests/supercede-existing-adr-madr.sh
+++ b/tests/supercede-existing-adr-madr.sh
@@ -1,0 +1,5 @@
+adr init docs madr
+adr new First Record
+adr new -s 2 Second Record
+head -10 docs/0002-first-record.md
+head -12 docs/0003-second-record.md

--- a/tests/supercede-existing-adr-madr.sh
+++ b/tests/supercede-existing-adr-madr.sh
@@ -2,4 +2,4 @@ adr init docs madr
 adr new First Record
 adr new -s 2 Second Record
 head -10 docs/0002-first-record.md
-head -12 docs/0003-second-record.md
+tail -5 docs/0003-second-record.md

--- a/tests/supercede-multiple-adrs-madr.expected
+++ b/tests/supercede-multiple-adrs-madr.expected
@@ -6,34 +6,22 @@ adr new Second Record
 docs/0003-second-record.md
 adr new -s 2 -s 3 Third Record
 docs/0004-third-record.md
-head -8 docs/0002-first-record.md
+head -5 docs/0002-first-record.md
 # First Record
 
-| Date | Status |
-| -- | -- |
-| 1992-01-12 | Accepted |
-| 1992-01-12 | Superceded by [Third Record](0004-third-record.md) |
-
-User Story: [ticket/issue-number] <!-- optional -->
-head -8 docs/0003-second-record.md
+* Status: Superceded by [Third Record](0004-third-record.md)
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: 1992-01-12
+head -5 docs/0003-second-record.md
 # Second Record
 
-| Date | Status |
-| -- | -- |
-| 1992-01-12 | Accepted |
-| 1992-01-12 | Superceded by [Third Record](0004-third-record.md) |
+* Status: Superceded by [Third Record](0004-third-record.md)
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: 1992-01-12
+tail -6 docs/0004-third-record.md
+## Links <!-- optional -->
 
-User Story: [ticket/issue-number] <!-- optional -->
-head -12 docs/0004-third-record.md
-# Third Record
-
-| Date | Status |
-| -- | -- |
-| 1992-01-12 | Accepted |
-| 1992-01-12 | Supercedes [First Record](0002-first-record.md) |
-| 1992-01-12 | Supercedes [Second Record](0003-second-record.md) |
-
-User Story: [ticket/issue-number] <!-- optional -->
-
-[context and problem statement]
-[decision drivers | forces | facing] <!-- optional -->
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->
+* Supercedes [First Record](0002-first-record.md)
+* Supercedes [Second Record](0003-second-record.md)

--- a/tests/supercede-multiple-adrs-madr.expected
+++ b/tests/supercede-multiple-adrs-madr.expected
@@ -1,0 +1,39 @@
+adr init docs madr
+docs/0001-record-architecture-decisions.md
+adr new First Record
+docs/0002-first-record.md
+adr new Second Record
+docs/0003-second-record.md
+adr new -s 2 -s 3 Third Record
+docs/0004-third-record.md
+head -8 docs/0002-first-record.md
+# First Record
+
+| Date | Status |
+| -- | -- |
+| 1992-01-12 | Accepted |
+| 1992-01-12 | Superceded by [Third Record](0004-third-record.md) |
+
+User Story: [ticket/issue-number] <!-- optional -->
+head -8 docs/0003-second-record.md
+# Second Record
+
+| Date | Status |
+| -- | -- |
+| 1992-01-12 | Accepted |
+| 1992-01-12 | Superceded by [Third Record](0004-third-record.md) |
+
+User Story: [ticket/issue-number] <!-- optional -->
+head -12 docs/0004-third-record.md
+# Third Record
+
+| Date | Status |
+| -- | -- |
+| 1992-01-12 | Accepted |
+| 1992-01-12 | Supercedes [First Record](0002-first-record.md) |
+| 1992-01-12 | Supercedes [Second Record](0003-second-record.md) |
+
+User Story: [ticket/issue-number] <!-- optional -->
+
+[context and problem statement]
+[decision drivers | forces | facing] <!-- optional -->

--- a/tests/supercede-multiple-adrs-madr.expected
+++ b/tests/supercede-multiple-adrs-madr.expected
@@ -1,27 +1,27 @@
 adr init docs madr
-docs/0001-record-architecture-decisions.md
+docs/0000-record-architecture-decisions.md
 adr new First Record
-docs/0002-first-record.md
+docs/0001-first-record.md
 adr new Second Record
-docs/0003-second-record.md
-adr new -s 2 -s 3 Third Record
-docs/0004-third-record.md
-head -5 docs/0002-first-record.md
+docs/0002-second-record.md
+adr new -s 1 -s 2 Third Record
+docs/0003-third-record.md
+head -5 docs/0001-first-record.md
 # First Record
 
-* Status: Superceded by [Third Record](0004-third-record.md)
+* Status: Superceded by [Third Record](0003-third-record.md)
 * Deciders: [list everyone involved in the decision] <!-- optional -->
 * Date: 1992-01-12
-head -5 docs/0003-second-record.md
+head -5 docs/0002-second-record.md
 # Second Record
 
-* Status: Superceded by [Third Record](0004-third-record.md)
+* Status: Superceded by [Third Record](0003-third-record.md)
 * Deciders: [list everyone involved in the decision] <!-- optional -->
 * Date: 1992-01-12
-tail -6 docs/0004-third-record.md
+tail -6 docs/0003-third-record.md
 ## Links <!-- optional -->
 
 * [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
 * … <!-- numbers of links can vary -->
-* Supercedes [First Record](0002-first-record.md)
-* Supercedes [Second Record](0003-second-record.md)
+* Supercedes [First Record](0001-first-record.md)
+* Supercedes [Second Record](0002-second-record.md)

--- a/tests/supercede-multiple-adrs-madr.sh
+++ b/tests/supercede-multiple-adrs-madr.sh
@@ -1,7 +1,7 @@
 adr init docs madr
 adr new First Record
 adr new Second Record
-adr new -s 2 -s 3 Third Record
-head -5 docs/0002-first-record.md
-head -5 docs/0003-second-record.md
-tail -6 docs/0004-third-record.md
+adr new -s 1 -s 2 Third Record
+head -5 docs/0001-first-record.md
+head -5 docs/0002-second-record.md
+tail -6 docs/0003-third-record.md

--- a/tests/supercede-multiple-adrs-madr.sh
+++ b/tests/supercede-multiple-adrs-madr.sh
@@ -2,6 +2,6 @@ adr init docs madr
 adr new First Record
 adr new Second Record
 adr new -s 2 -s 3 Third Record
-head -8 docs/0002-first-record.md
-head -8 docs/0003-second-record.md
-head -12 docs/0004-third-record.md
+head -5 docs/0002-first-record.md
+head -5 docs/0003-second-record.md
+tail -6 docs/0004-third-record.md

--- a/tests/supercede-multiple-adrs-madr.sh
+++ b/tests/supercede-multiple-adrs-madr.sh
@@ -1,0 +1,7 @@
+adr init docs madr
+adr new First Record
+adr new Second Record
+adr new -s 2 -s 3 Third Record
+head -8 docs/0002-first-record.md
+head -8 docs/0003-second-record.md
+head -12 docs/0004-third-record.md


### PR DESCRIPTION
This PR adds dedicated support for the [Markdown Archicturual Decision Records](http://adr.github.io/madr) by @koppor and @socadk. A user can now initialize the repository using adr init DIR madr.  MADR not only uses a different template.md, but also a different status format (see https://github.com/adr/madr/issues/2). This is necessary, because MADR requires date and status information only when the status is not "Accepted".

We would be happy if this was included in adr-tools as adr-tools eases working with ADRs.