### PR TITLE
fix custom template instructions

### DIFF
--- a/src/adr-new
+++ b/src/adr-new
@@ -11,7 +11,7 @@ eval "$($(dirname $0)/adr-config)"
 ## file name of the ADR is output to stdout, so the command can be used in
 ## scripts.
 ##
-## If the ADR directory contains a file named `template.md`, this is used as
+## If the ADR directory contains a file `templates/template.md`, this is used as
 ## the template for the new ADR.  Otherwise a default template is used that
 ## follows the style described by Michael Nygard in this article:
 ##


### PR DESCRIPTION
Just noticed that there's a small mismatch between implementation + documentation. 

Wording could be done differently but I figured this is probably clearer than saying "if there's a directory `templates/` and a file `template.md` in this directory it is used..." 

Maybe also the implementation is wrong and the docs are correct? 😆 