### PR TITLE
Minor bugfix documenting where to put the template for new ADRs.

### DIFF
--- a/src/adr-new
+++ b/src/adr-new
@@ -11,9 +11,10 @@ eval "$($(dirname $0)/adr-config)"
 ## file name of the ADR is output to stdout, so the command can be used in
 ## scripts.
 ##
-## If the ADR directory contains a file named `template.md`, this is used as
-## the template for the new ADR.  Otherwise a default template is used that
-## follows the style described by Michael Nygard in this article:
+## If the ADR directory contains a `template` directory which has a
+## file named `template.md`, this is used as the template for the new
+## ADR.  Otherwise a default template is used that follows the style
+## described by Michael Nygard in this article:
 ##
 ##   http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
 ##


### PR DESCRIPTION
The template is in a subdirectory (which is good),
but the source code documentation does not know that yet (which is bad).