### PR TITLE
[WINDOWS] Enable `adr new` under git bash

### DIFF
--- a/src/adr-new
+++ b/src/adr-new
@@ -93,14 +93,14 @@ fi
 
 if [ -d $dstdir ]
 then
-    maxid=$(ls $dstdir | grep -Eo '^[0-9]+' | sed -e 's/^0*//' | sort -rn | head -1)
+    maxid=$(ls $dstdir | awk '{ match($0, /^([0-9]+)/); id=substr($0, RSTART, RLENGTH); print id; }' | sed -e 's/^0*//' | sort -rn | head -1)
     newnum=$(($maxid + 1))
 else
     newnum=1
 fi
 
 newid=$(printf "%04d" $newnum)
-slug=$(echo -n $title | tr -Ccs [:alnum:] - | tr [:upper:] [:lower:] | sed -e 's/[^[:alnum:]]*$//' -e 's/^[^[:alnum:]]*//')
+slug=$(echo -n $title | tr -cs [:alnum:] - | tr [:upper:] [:lower:] | sed -e 's/[^[:alnum:]]*$//' -e 's/^[^[:alnum:]]*//')
 dstfile=$dstdir/$newid-$slug.md
 date=${ADR_DATE:-$(date +%Y-%m-%d)}
 

--- a/tests/names-may-contain-numbers.expected
+++ b/tests/names-may-contain-numbers.expected
@@ -1,0 +1,13 @@
+adr new 99 Luft Balloons
+doc/adr/0001-99-luft-balloons.md
+adr new Song 2
+doc/adr/0002-song-2.md
+adr new 1999
+doc/adr/0003-1999.md
+adr new 9 to 5
+doc/adr/0004-9-to-5.md
+ls doc/adr
+0001-99-luft-balloons.md
+0002-song-2.md
+0003-1999.md
+0004-9-to-5.md

--- a/tests/names-may-contain-numbers.sh
+++ b/tests/names-may-contain-numbers.sh
@@ -1,0 +1,5 @@
+adr new 99 Luft Balloons
+adr new Song 2
+adr new 1999
+adr new 9 to 5
+ls doc/adr


### PR DESCRIPTION
Hey I ran into a couple of problems with `adr new` under `git bash`, I tried with latest mysysgit with no luck.

```
$ git --version
git version 1.9.5.msysgit.1
```

Do these changes seem reasonable?

[Tests passing](https://travis-ci.org/ben-biddington/adr-tools) including extra proof that [maxid takes only digit prefix](https://github.com/ben-biddington/adr-tools/blob/master/tests/names-may-contain-numbers.sh), ignoring other digits in titles.