### PR TITLE
Make adr work through a symlink

### DIFF
--- a/src/adr
+++ b/src/adr
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$(readlink -f "$0")" )"/adr-config)"
 
 cmd=$adr_bin_dir/adr-$1
 


### PR DESCRIPTION
This PR allows someone to symlink src/adr into an existing directory on their PATH, without bringing the other scripts with it.  readlink will correctly determine where adr is *actually* installed and access the rest of the scripts from there.