### PR TITLE
Support invocation of adr from paths that contain symlinks

### DIFF
--- a/src/adr
+++ b/src/adr
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+
+dir=$(dirname "$(readlink -f "$0")")
+eval "$("${dir}"/adr-config)"
 
 cmd=$adr_bin_dir/adr-$1
 

--- a/tests/invoked-from-path-containing-symlink.expected
+++ b/tests/invoked-from-path-containing-symlink.expected
@@ -1,0 +1,3 @@
+ln -s ../../../src/adr adr
+./adr | head -1
+usage: adr help COMMAND [ARG] ...

--- a/tests/invoked-from-path-containing-symlink.sh
+++ b/tests/invoked-from-path-containing-symlink.sh
@@ -1,0 +1,2 @@
+ln -s ../../../src/adr adr
+./adr | head -1


### PR DESCRIPTION
adr fails when invoked as a symlink. For example:

```
# ls
adr-tools-2.1.0
# ln -s adr-tools-2.1.0/src/adr adr
# ./adr
./adr: line 3: ./adr-config: No such file or directory
./adr: line 11: /adr-help: No such file or directory
```

This PR adds a test for this that fails then fixes the issue.