### PR TITLE
Adding auto generation of table of contents

### DIFF
--- a/src/adr-toc
+++ b/src/adr-toc
@@ -14,47 +14,4 @@ adr_contents="0000-contents.md"
 ##
 ## Both INTRO and OUTRO must be in Markdown format.
 
-args=$(getopt i:o: $*)
-set -- $args
-
-for arg
-do
-    case "$arg"
-    in
-        -i)
-            intro="$2"
-            shift 2
-            ;;
-        -o)
-            outro="$2"
-            shift 2
-            ;;
-        --)
-            shift
-            break
-            ;;
-    esac
-done
-
-echo "# Architecture Decision Records" > "$adr_dir/$adr_contents"
-echo >> "$adr_dir/$adr_contents"
-
-if [ ! -z $intro ]
-then
-    echo $intro > "$adr_dir/$adr_contents"
-    echo > "$adr_dir/$adr_contents"
-fi
-
-for f in $("$adr_bin_dir/adr-list")
-do
-    title=$("$adr_bin_dir/_adr_title" $f)
-    link=$(basename $f)
-
-    echo "* [$title]($link)"
-done | grep -v "$adr_contents" >> "$adr_dir/$adr_contents"
-
-if [ ! -z $outro ]
-then
-    echo > "$adr_dir/$adr_contents"
-	echo $outro > "$adr_dir/$adr_contents"
-fi
+("$adr_bin_dir/adr-generate" toc) | grep -v "$adr_contents" > "$adr_dir/$adr_contents"

--- a/src/adr-toc
+++ b/src/adr-toc
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+eval "$($(dirname $0)/adr-config)"
+adr_dir=$("$adr_bin_dir/_adr_dir")
+adr_contents="0000-contents.md"
+## usage: adr toc [-i INTRO] [-o OUTRO]
+##
+## Generates a table of contents in Markdown format to contents.md file in the adr folder.
+##
+## Options:
+##
+## -e INTRO  precede the table of contents with the given INTRO text.
+## -o OUTRO  follow the table of contents with the given OUTRO text.
+##
+## Both INTRO and OUTRO must be in Markdown format.
+
+args=$(getopt i:o: $*)
+set -- $args
+
+for arg
+do
+    case "$arg"
+    in
+        -i)
+            intro="$2"
+            shift 2
+            ;;
+        -o)
+            outro="$2"
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+    esac
+done
+
+echo "# Architecture Decision Records" > "$adr_dir/$adr_contents"
+echo >> "$adr_dir/$adr_contents"
+
+if [ ! -z $intro ]
+then
+    echo $intro > "$adr_dir/$adr_contents"
+    echo > "$adr_dir/$adr_contents"
+fi
+
+for f in $("$adr_bin_dir/adr-list")
+do
+    title=$("$adr_bin_dir/_adr_title" $f)
+    link=$(basename $f)
+
+    echo "* [$title]($link)"
+done | grep -v "$adr_contents" >> "$adr_dir/$adr_contents"
+
+if [ ! -z $outro ]
+then
+    echo > "$adr_dir/$adr_contents"
+	echo $outro > "$adr_dir/$adr_contents"
+fi

--- a/tests/autocomplete.expected
+++ b/tests/autocomplete.expected
@@ -1,5 +1,5 @@
 _adr_autocomplete adr
-config generate help init link list new upgrade-repository
+config generate help init link list new toc upgrade-repository
 _adr_autocomplete adr li
 link list
 _adr_autocomplete adr generate

--- a/tests/toc.expected
+++ b/tests/toc.expected
@@ -1,0 +1,13 @@
+adr new First Decision
+doc/adr/0001-first-decision.md
+adr new Second Decision
+doc/adr/0002-second-decision.md
+adr new Third Decision
+doc/adr/0003-third-decision.md
+adr toc
+cat doc/adr/0000-contents.md
+# Architecture Decision Records
+
+* [1. First Decision](0001-first-decision.md)
+* [2. Second Decision](0002-second-decision.md)
+* [3. Third Decision](0003-third-decision.md)

--- a/tests/toc.sh
+++ b/tests/toc.sh
@@ -1,0 +1,5 @@
+adr new First Decision
+adr new Second Decision
+adr new Third Decision
+adr toc
+cat doc/adr/0000-contents.md


### PR DESCRIPTION
Instead of needing to redirect the toc to a file manually, this generates a new toc and creates or replaces a contents.md file in the  adr folder.