### PR TITLE
Fix minor typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Quick Start
 
 [Install ADR Tools](INSTALL.md).
 
-Use the `adr` command to manage ADRs.  Try running `adr help`.
+Use the `adr` command to manage ADRs. Try running `adr help`.
 
 ADRs are stored in a subdirectory of your project as Markdown files. 
 The default directory is `doc/adr`, but you can specify the directory
@@ -33,14 +33,14 @@ when you initialise the ADR log.
     editor of choice (as specified by the VISUAL or EDITOR environment
     variable).
 
-    To create a new ADR that supercedes a previous one (ADR 9, for example),
+    To create a new ADR that supersedes a previous one (ADR 9, for example),
     use the -s option.
 
         adr new -s 9 Use Rust for performance-critical functionality
 
-    This will create a new ADR file that is flagged as superceding
+    This will create a new ADR file that is flagged as superseding
     ADR 9, and changes the status of ADR 9 to indicate that it is
-    superceded by the new ADR.  It then opens the new ADR in your
+    superseded by the new ADR. It then opens the new ADR in your
     editor of choice.
     
 3. For further information, use the built in help:
@@ -48,8 +48,8 @@ when you initialise the ADR log.
         adr help
 
 
-See the [tests](tests/) for detailed examples.
+See the [tests](tests) for detailed examples.
 
-The decisions for this tool are recorded as [architecture decision records in the project repository](doc/adr/). 
+The decisions for this tool are recorded as [architecture decision records in the project repository](doc/adr).
 
 [ADRs]: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions


### PR DESCRIPTION
Fix typos on 'supersede' and make minor style changes:
- remove unneeded spaces
- fix relative link warnings in IntelliJ IDEA

`supercede` is visibly often used but seems incorrect (see https://en.oxforddictionaries.com/definition/us/supercede). :innocent: 