### PR TITLE
TOC: Style deprecated or superceded records

### DIFF
--- a/src/_adr_generate_toc
+++ b/src/_adr_generate_toc
@@ -56,10 +56,17 @@ fi
 
 for f in $("$adr_bin_dir/adr-list")
 do
-    title=$("$adr_bin_dir/_adr_title" $f)
+    status=$($adr_bin_dir/_adr_status $f)
+    comment=""
+    if [[ ${status^^} =~ ^DEPRECATED ]] || [[ ${status^^} =~ ^SUPERCEDED ]]; then
+        title="~~$("$adr_bin_dir/_adr_title" $f)~~"
+        comment=" _($status)_"
+    else
+        title=$("$adr_bin_dir/_adr_title" $f)
+    fi
     link=${link_prefix}$(basename $f)
 
-    echo "* [$title]($link)"
+    echo "* [$title]($link)$comment"
 done
 
 if [ ! -z $outro ]

--- a/src/_adr_generate_toc
+++ b/src/_adr_generate_toc
@@ -60,7 +60,7 @@ do
     comment=""
     if [[ ${status^^} =~ ^DEPRECATED ]] || [[ ${status^^} =~ ^SUPERCEDED ]]; then
         title="~~$("$adr_bin_dir/_adr_title" $f)~~"
-        comment=" _($status)_"
+        comment=" _(${status/](/](${link_prefix}})_"
     else
         title=$("$adr_bin_dir/_adr_title" $f)
     fi

--- a/tests/generate-contents-supercede.expected
+++ b/tests/generate-contents-supercede.expected
@@ -1,0 +1,9 @@
+adr new First Decision
+doc/adr/0001-first-decision.md
+adr new -s 1 Second Decision
+doc/adr/0002-second-decision.md
+adr generate toc -p foo/doc/adr/
+# Architecture Decision Records
+
+* [~~1. First Decision~~](foo/doc/adr/0001-first-decision.md) _(Superceded by [2. Second Decision](foo/doc/adr/0002-second-decision.md))_
+* [2. Second Decision](foo/doc/adr/0002-second-decision.md)

--- a/tests/generate-contents-supercede.sh
+++ b/tests/generate-contents-supercede.sh
@@ -1,0 +1,3 @@
+adr new First Decision
+adr new -s 1 Second Decision
+adr generate toc -p foo/doc/adr/


### PR DESCRIPTION
In the toc, for records that have either status deprecated or superceded:
    - strikethrough link
    - add status in parenthesis after the link and emphasise
