### PR TITLE
Fix adr init on OSX

### DIFF
--- a/src/_adr_dir
+++ b/src/_adr_dir
@@ -13,7 +13,7 @@ function absdir() {
 	(cd $(dirname $1) && pwd -P)
 }
 
-while [ $(absdir $reldir) != / ]
+while [ "$(absdir $reldir)" != "/" ]
 do
 	if [ -f $(mkrel .adr-dir) ]
 	then


### PR DESCRIPTION
This fixes the error I get when trying to run the init command on osx using either system's bash 3.2 or homebrew's 5.0.7.

Error message was:
```
$ adr init docs/architecture
/usr/local/Cellar/adr-tools/3.0.0/bin/_adr_dir: line 16: [: too many arguments
doc/adr/0001-record-architecture-decisions.md
```

Probably more things should be quoted in this codebase.