### PR TITLE
Support explicit ADR numbering

### DIFF
--- a/src/_adr_help_new
+++ b/src/_adr_help_new
@@ -3,7 +3,7 @@ set -e
 eval "$($(dirname $0)/adr-config)"
 
 cat <<ENDHELP
-usage: adr new [-s SUPERCEDED] [-l TARGET:LINK:REVERSE-LINK] TITLE_TEXT...
+usage: adr new [-n NUMBER] [-s SUPERCEDED] [-l TARGET:LINK:REVERSE-LINK] TITLE_TEXT...
 
 Creates a new, numbered ADR.  The TITLE_TEXT arguments are concatenated to
 form the title of the new ADR.  The ADR is opened for editing in the
@@ -23,6 +23,8 @@ This template follows the style described by Michael Nygard in this article.
 
 Options:
 
+-n NUMBER       Create the new ADR with a given number.
+
 -s SUPERCEDED   A reference (number or partial filename) of a previous
                 decision that the new decision supercedes. A Markdown link
                 to the superceded ADR is inserted into the Status section.
@@ -30,14 +32,14 @@ Options:
                 it has been superceded by the new ADR.
 
 -l TARGET:LINK:REVERSE-LINK
-                Links the new ADR to a previous ADR.  
-                TARGET is a reference (number or partial filename) of a 
-                previous decision. 
+                Links the new ADR to a previous ADR.
+                TARGET is a reference (number or partial filename) of a
+                previous decision.
                 LINK is the description of the link created in the new ADR.
                 REVERSE-LINK is the description of the link created in the
                 existing ADR that will refer to the new ADR.
 
-Multiple -s and -l options can be given, so that the new ADR can supercede 
+Multiple -s and -l options can be given, so that the new ADR can supercede
 or link to multiple existing ADRs.
 
 E.g. to create a new ADR with the title "Use MySQL Database":

--- a/src/adr-new
+++ b/src/adr-new
@@ -2,7 +2,7 @@
 set -e
 eval "$($(dirname $0)/adr-config)"
 
-## usage: adr new [-s SUPERCEDED] [-l TARGET:LINK:REVERSE-LINK] TITLE_TEXT...
+## usage: adr new [-n NUMBER] [-s SUPERCEDED] [-l TARGET:LINK:REVERSE-LINK] TITLE_TEXT...
 ##
 ## Creates a new, numbered ADR.  The TITLE_TEXT arguments are concatenated to
 ## form the title of the new ADR.  The ADR is opened for editing in the
@@ -19,6 +19,8 @@ eval "$($(dirname $0)/adr-config)"
 ##
 ## Options:
 ##
+## -n NUMBER       Create the new ADR with a given number.
+##
 ## -s SUPERCEDED   A reference (number or partial filename) of a previous
 ##                 decision that the new decision supercedes. A Markdown link
 ##                 to the superceded ADR is inserted into the Status section.
@@ -26,14 +28,14 @@ eval "$($(dirname $0)/adr-config)"
 ##                 it has been superceded by the new ADR.
 ##
 ## -l TARGET:LINK:REVERSE-LINK
-##                 Links the new ADR to a previous ADR.  
-##                 TARGET is a reference (number or partial filename) of a 
-##                 previous decision. 
+##                 Links the new ADR to a previous ADR.
+##                 TARGET is a reference (number or partial filename) of a
+##                 previous decision.
 ##                 LINK is the description of the link created in the new ADR.
 ##                 REVERSE-LINK is the description of the link created in the
 ##                 existing ADR that will refer to the new ADR.
 ##
-## Multiple -s and -l options can be given, so that the new ADR can supercede 
+## Multiple -s and -l options can be given, so that the new ADR can supercede
 ## or link to multiple existing ADRs.
 ##
 ## E.g. to create a new ADR with the title "Use MySQL Database":
@@ -48,13 +50,26 @@ eval "$($(dirname $0)/adr-config)"
 ##
 ##     adr new -s 3 -s 4 -l "5:Amends:Amended by" Use Riak CRDTs to cope with scale
 ##
+## E.g. to create a new ADR with an explicit number:
+##
+##     adr new -n 42 User PostgreSQL Database
+##
 
 superceded=()
 links=()
+newnum=()
 
-while getopts s:l: arg
+while getopts n:s:l: arg
 do
     case "$arg" in
+        n)
+            if [ -n "$newnum" ];
+            then
+                echo "ERROR: multiple numbers given"
+                exit 1
+            fi
+            newnum="$OPTARG"
+            ;;
         s)
             superceded+=("$OPTARG")
             ;;
@@ -91,12 +106,25 @@ then
     exit 1
 fi
 
+if [ -z "$newnum" ]
+then
+    if [ -d $dstdir ]
+    then
+        maxid=$(ls $dstdir | grep -Eo '^[0-9]+' | sed -e 's/^0*//' | sort -rn | head -1)
+        newnum=$(($maxid + 1))
+    else
+        newnum=1
+    fi
+fi
+
 if [ -d $dstdir ]
 then
-    maxid=$(ls $dstdir | grep -Eo '^[0-9]+' | sed -e 's/^0*//' | sort -rn | head -1)
-    newnum=$(($maxid + 1))
-else
-    newnum=1
+    existingadr=$(ls $dstdir | grep -Eo '^0*'$newnum'\D' | sed -e 's/^0*//')
+    if [ -n "$existingadr" ]
+    then
+        echo "ERROR: ADR number $newnum already exists"
+        exit 1
+    fi
 fi
 
 newid=$(printf "%04d" $newnum)
@@ -124,7 +152,7 @@ do
 	target="$(echo $l | cut -d : -f 1)"
 	forward_link="$(echo $l | cut -d : -f 2)"
 	reverse_link="$(echo $l | cut -d : -f 3)"
-	
+
 	"$adr_bin_dir/_adr_add_link" "$dstfile" "$forward_link" "$target"
 	"$adr_bin_dir/_adr_add_link" "$target" "$reverse_link" "$dstfile"
 done

--- a/src/adr-new
+++ b/src/adr-new
@@ -117,14 +117,10 @@ then
     fi
 fi
 
-if [ -d $dstdir ]
+if ls $dstdir/0*$newnum-* 1>/dev/null 2>&1
 then
-    existingadr=$(ls $dstdir | grep -Eo '^0*'$newnum'\D' | sed -e 's/^0*//')
-    if [ -n "$existingadr" ]
-    then
-        echo "ERROR: ADR number $newnum already exists"
-        exit 1
-    fi
+    echo "ERROR: ADR number $newnum already exists"
+    exit 1
 fi
 
 newid=$(printf "%04d" $newnum)

--- a/tests/create-first-explicitly-numbered-record.expected
+++ b/tests/create-first-explicitly-numbered-record.expected
@@ -1,0 +1,22 @@
+adr new -n 52 The First Decision
+doc/adr/0052-the-first-decision.md
+cat doc/adr/0052-the-first-decision.md
+# 52. The First Decision
+
+Date: 1992-01-12
+
+## Status
+
+Accepted
+
+## Context
+
+The issue motivating this decision, and any context that influences or constrains the decision.
+
+## Decision
+
+The change that we're proposing or have agreed to implement.
+
+## Consequences
+
+What becomes easier or more difficult to do and any risks introduced by the change that will need to be mitigated.

--- a/tests/create-first-explicitly-numbered-record.sh
+++ b/tests/create-first-explicitly-numbered-record.sh
@@ -1,0 +1,2 @@
+adr new -n 52 The First Decision
+cat doc/adr/0052-the-first-decision.md

--- a/tests/must-provide-a-nonexisting-adr-number.expected
+++ b/tests/must-provide-a-nonexisting-adr-number.expected
@@ -1,0 +1,11 @@
+adr new The First Decision
+doc/adr/0001-the-first-decision.md
+adr new The Second Decision
+doc/adr/0002-the-second-decision.md
+adr new The Third Decision
+doc/adr/0003-the-third-decision.md
+if adr new -n 2 The Fourth Decision
+then
+    echo ERROR: should have failed
+fi
+ERROR: ADR number 2 already exists

--- a/tests/must-provide-a-nonexisting-adr-number.sh
+++ b/tests/must-provide-a-nonexisting-adr-number.sh
@@ -1,0 +1,7 @@
+adr new The First Decision
+adr new The Second Decision
+adr new The Third Decision
+if adr new -n 2 The Fourth Decision
+then
+    echo ERROR: should have failed
+fi

--- a/tests/must-provide-a-single-number-when-creating-new-adr.expected
+++ b/tests/must-provide-a-single-number-when-creating-new-adr.expected
@@ -1,0 +1,5 @@
+if adr new -n 23 -n 24 Test ADR
+then
+    echo ERROR: should have failed
+fi
+ERROR: multiple numbers given

--- a/tests/must-provide-a-single-number-when-creating-new-adr.sh
+++ b/tests/must-provide-a-single-number-when-creating-new-adr.sh
@@ -1,0 +1,4 @@
+if adr new -n 23 -n 24 Test ADR
+then
+    echo ERROR: should have failed
+fi


### PR DESCRIPTION
Sometimes existing ADRs might not be the only ones existing in the adr directory. For example, there might be other ADRs under review in a pull request.

Creating the next ADR via `adr new <title>` could lead in this case to an undesired number to be picked. Other (arbitrary) systems may be used to manage ADR numbering.

To allow this it is desirable to parametrize `adr new` to allow creating the next ADR with an explicit number.