### PR TITLE
make scripts portable with #!/usr/bin/env shebang

### DIFF
--- a/approve
+++ b/approve
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 test="${1:?test}"

--- a/src/_adr_add_link
+++ b/src/_adr_add_link
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/_adr_autocomplete
+++ b/src/_adr_autocomplete
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 eval "$($(dirname $0)/adr-config)"
 
 cmds=("$@")

--- a/src/_adr_commands
+++ b/src/_adr_commands
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/_adr_dir
+++ b/src/_adr_dir
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/_adr_file
+++ b/src/_adr_file
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/_adr_generate_graph
+++ b/src/_adr_generate_graph
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/_adr_generate_toc
+++ b/src/_adr_generate_toc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/_adr_help
+++ b/src/_adr_help
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/_adr_help_new
+++ b/src/_adr_help_new
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/_adr_links
+++ b/src/_adr_links
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/_adr_remove_status
+++ b/src/_adr_remove_status
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/_adr_status
+++ b/src/_adr_status
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/_adr_title
+++ b/src/_adr_title
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/adr
+++ b/src/adr
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/adr-config
+++ b/src/adr-config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Config for when running from the source directory.
 
 basedir=$(cd -L $(dirname $0) >/dev/null 2>&1 && pwd -L)

--- a/src/adr-generate
+++ b/src/adr-generate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/adr-help
+++ b/src/adr-help
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/adr-init
+++ b/src/adr-init
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/adr-link
+++ b/src/adr-link
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/adr-list
+++ b/src/adr-list
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/adr-new
+++ b/src/adr-new
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 

--- a/src/adr-upgrade-repository
+++ b/src/adr-upgrade-repository
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 eval "$($(dirname $0)/adr-config)"
 


### PR DESCRIPTION
In some Linux/Unix environments install `bash` outside of `/bin` directory. This PR aims to make the scripts portable for those.