### PR TITLE
Use link to re-homed blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ See the [tests](tests/) for detailed examples.
 
 The decisions for this tool are recorded as [architecture decision records in the project repository](doc/adr/). 
 
-[ADRs]: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+[ADRs]: http://blog.cognitect.com/2011/11/15/documenting-architecture-decisions.html

--- a/src/_adr_help_new
+++ b/src/_adr_help_new
@@ -19,7 +19,7 @@ the template for the new ADR.  Otherwise the following file is used:
 
 This template follows the style described by Michael Nygard in this article.
 
-  http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+  http://blog.cognitect.com/2011/11/15/documenting-architecture-decisions.html
 
 Options:
 

--- a/src/adr-new
+++ b/src/adr-new
@@ -15,7 +15,7 @@ eval "$($(dirname $0)/adr-config)"
 ## the template for the new ADR.  Otherwise a default template is used that
 ## follows the style described by Michael Nygard in this article:
 ##
-##   http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+##   http://blog.cognitect.com/2011/11/15/documenting-architecture-decisions.html
 ##
 ## Options:
 ##

--- a/src/init.md
+++ b/src/init.md
@@ -12,7 +12,7 @@ We need to record the architectural decisions made on this project.
 
 ## Decision
 
-We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+We will use Architecture Decision Records, as [described by Michael Nygard](http://blog.cognitect.com/2011/11/15/documenting-architecture-decisions.html).
 
 ## Consequences
 

--- a/tests/init-adr-repository.expected
+++ b/tests/init-adr-repository.expected
@@ -17,7 +17,7 @@ We need to record the architectural decisions made on this project.
 
 ## Decision
 
-We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+We will use Architecture Decision Records, as [described by Michael Nygard](http://blog.cognitect.com/2011/11/15/documenting-architecture-decisions.html).
 
 ## Consequences
 


### PR DESCRIPTION
The old thinkrelevance.com blog had been responding poorly. Cognitect (the successor org to Relevance) has re-homed the post on their actively-maintained blog.