### PR TITLE
Add support for Asciidoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Quick Start
 
 Use the `adr` command to manage ADRs.  Try running `adr help`.
 
-ADRs are stored in a subdirectory of your project as Markdown files. 
+ADRs are stored in a subdirectory of your project as Markdown files by default,
+but you can specify AsciiDoc format when you initialise the ADR log.
 The default directory is `doc/adr`, but you can specify the directory
 when you initialise the ADR log.
 
@@ -20,10 +21,14 @@ when you initialise the ADR log.
 
         adr init doc/architecture/decisions
 
-    This will create a directory named `doc/architecture/decisions` 
+    This will create a directory named `doc/architecture/decisions`
     containing the first ADR, which records that you are using ADRs
-    to record architectural decisions and links to 
+    to record architectural decisions and links to
     [Michael Nygard's article on the subject][ADRs].
+
+    If you want your ADR files in AsciiDoc instead of Markdown, use the `-t adoc` option.
+
+        adr init -t adoc doc/architecture/decisions
 
 2. Create Architecture Decision Records
 
@@ -42,7 +47,7 @@ when you initialise the ADR log.
     ADR 9, and changes the status of ADR 9 to indicate that it is
     superceded by the new ADR.  It then opens the new ADR in your
     editor of choice.
-    
+
 3. For further information, use the built in help:
 
         adr help
@@ -50,6 +55,6 @@ when you initialise the ADR log.
 
 See the [tests](tests/) for detailed examples.
 
-The decisions for this tool are recorded as [architecture decision records in the project repository](doc/adr/). 
+The decisions for this tool are recorded as [architecture decision records in the project repository](doc/adr/).
 
 [ADRs]: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions

--- a/src/_adr_add_link
+++ b/src/_adr_add_link
@@ -9,7 +9,7 @@ target=$("$adr_bin_dir/_adr_file" "${3:?TARGET}")
 target_title="$("$adr_bin_dir/_adr_title" "$target")"
 
 awk -v link_type="$link_type" -v target="$(basename $target)" -v target_title="$target_title" '
-	BEGIN { 
+	BEGIN {
 		in_status_section=0
 	}
 	/^##/ {
@@ -19,8 +19,15 @@ awk -v link_type="$link_type" -v target="$(basename $target)" -v target_title="$
 		}
 		in_status_section=0
 	}
-	/^## Status$/ { 
-		in_status_section=1 
+	/^==/ {
+		if (in_status_section) {
+      print link_type " link:" target "[" target_title "]"
+			print ""
+		}
+		in_status_section=0
+	}
+	/^[#=]{2} Status$/ {
+		in_status_section=1
 	}
 	{ print }
 ' "$source" > "$source.tmp"

--- a/src/_adr_file_type
+++ b/src/_adr_file_type
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+eval "$($(dirname $0)/adr-config)"
+
+reldir=.
+
+function mkrel() {
+	local d=$reldir/$1
+	echo ${d#./}
+}
+
+function absdir() {
+	(cd $(dirname $1) && pwd -P)
+}
+
+while [ $(absdir $reldir) != / ]
+do
+	if [ -f $(mkrel .adr-file-type) ]
+	then
+	    cat $(mkrel .adr-file-type)
+		exit
+	else
+		reldir=$reldir/..
+	fi
+done
+echo md

--- a/src/_adr_generate_graph
+++ b/src/_adr_generate_graph
@@ -5,21 +5,21 @@ eval "$($(dirname $0)/adr-config)"
 ## usage: adr generate graph [-p LINK_PREFIX] [-e LINK-EXTENSION]
 ##
 ## Generates a visualisation of the links between decision records in
-## Graphviz format.  This can be piped into the graphviz tools to 
+## Graphviz format.  This can be piped into the graphviz tools to
 ## generate a an image file.
-## 
+##
 ## Each node in the graph represents a decision record and is linked to
-## the decision record document.  
+## the decision record document.
 ##
 ## Options:
 ##
-## -e LINK-EXTENSION 
-##         the file extension of the documents to which generated links refer. 
+## -e LINK-EXTENSION
+##         the file extension of the documents to which generated links refer.
 ##         Defaults to `.html`.
-## 
-## -p LINK_PREFIX 
+##
+## -p LINK_PREFIX
 ##         prefix each decision file link with LINK_PREFIX.
-## 
+##
 ## E.g. to generate a graph visualisation of decision records in SVG format:
 ##
 ##     adr generate graph | dot -Tsvg > graph.svg
@@ -31,11 +31,12 @@ eval "$($(dirname $0)/adr-config)"
 
 link_prefix=
 link_extension=.html
+file_type="$($adr_bin_dir/_adr_file_type)"
 
 while getopts e:p: arg
 do
     case "$arg" in
-        e) 
+        e)
 			link_extension="$OPTARG"
           	;;
 		p)
@@ -62,8 +63,8 @@ for f in $("$adr_bin_dir/adr-list")
 do
 	n=$(index "$f")
 	title=$("$adr_bin_dir/_adr_title" $f)
-	
-	echo "    _$n [label=\"$title\"; URL=\"${link_prefix}$(basename $f .md)${link_extension}\"];"
+
+	echo "    _$n [label=\"$title\"; URL=\"${link_prefix}$(basename $f ".$file_type")${link_extension}\"];"
 	if [ $n -gt 1 ]
 	then
 		echo "    _$(($n - 1)) -> _$n [style=\"dotted\", weight=1];"

--- a/src/_adr_generate_toc
+++ b/src/_adr_generate_toc
@@ -4,16 +4,17 @@ eval "$($(dirname $0)/adr-config)"
 
 ## usage: adr generate toc [-i INTRO] [-o OUTRO] [-p LINK_PREFIX]
 ##
-## Generates a table of contents in Markdown format to stdout.
+## Generates a table of contents in project format (Markdown or
+## Asciidoc) to stdout.
 ##
 ## Options:
 ##
 ## -i INTRO  precede the table of contents with the given INTRO text.
 ## -o OUTRO  follow the table of contents with the given OUTRO text.
-## -p LINK_PREFIX   
+## -p LINK_PREFIX
 ##           prefix each decision file link with LINK_PREFIX.
 ##
-## Both INTRO and OUTRO must be in Markdown format.
+## Both INTRO and OUTRO must be in project format.
 
 args=$(getopt i:o:p: $*)
 set -- $args
@@ -44,7 +45,7 @@ do
 done
 
 cat <<EOF
-# Architecture Decision Records
+$("$adr_bin_dir/_adr_text_header" 1 'Architecture Decision Records')
 
 EOF
 
@@ -59,7 +60,7 @@ do
     title=$("$adr_bin_dir/_adr_title" $f)
     link=${link_prefix}$(basename $f)
 
-    echo "* [$title]($link)"
+    echo "* $("$adr_bin_dir/_adr_text_link" "$title" "$link")"
 done
 
 if [ ! -z $outro ]

--- a/src/_adr_help_new
+++ b/src/_adr_help_new
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 eval "$($(dirname $0)/adr-config)"
+file_type="$($adr_bin_dir/_adr_file_type)"
 
 cat <<ENDHELP
 usage: adr new [-s SUPERCEDED] [-l TARGET:LINK:REVERSE-LINK] TITLE_TEXT...
@@ -12,10 +13,10 @@ preferred; EDITOR is used if VISUAL is not set).  After editing, the
 file name of the ADR is output to stdout, so the command can be used in
 scripts.
 
-If the ADR directory contains a file `templates/template.md`, this is used as
+If the ADR directory contains a file `templates/template.${file_type}`, this is used as
 the template for the new ADR.  Otherwise the following file is used:
 
-  ${adr_template_dir}/template.md
+  ${adr_template_dir}/template.${file_type}
 
 This template follows the style described by Michael Nygard in this article.
 
@@ -30,14 +31,14 @@ Options:
                 it has been superceded by the new ADR.
 
 -l TARGET:LINK:REVERSE-LINK
-                Links the new ADR to a previous ADR.  
-                TARGET is a reference (number or partial filename) of a 
-                previous decision. 
+                Links the new ADR to a previous ADR.
+                TARGET is a reference (number or partial filename) of a
+                previous decision.
                 LINK is the description of the link created in the new ADR.
                 REVERSE-LINK is the description of the link created in the
                 existing ADR that will refer to the new ADR.
 
-Multiple -s and -l options can be given, so that the new ADR can supercede 
+Multiple -s and -l options can be given, so that the new ADR can supercede
 or link to multiple existing ADRs.
 
 E.g. to create a new ADR with the title "Use MySQL Database":

--- a/src/_adr_links
+++ b/src/_adr_links
@@ -2,4 +2,11 @@
 set -e
 eval "$($(dirname $0)/adr-config)"
 
-"$adr_bin_dir/_adr_status" "$1" | sed -n -E 's/^(.+) \[.*\]\(0*([1-9][0-9]*).*\)/\2=\1/p'
+file_type="$($adr_bin_dir/_adr_file_type)"
+
+if [ "$file_type" = "md" ]
+then
+  "$adr_bin_dir/_adr_status" "$1" | sed -n -E 's/^(.+) \[.*\]\(0*([1-9][0-9]*).*\)/\2=\1/p'
+else
+  "$adr_bin_dir/_adr_status" "$1" | sed -n -E 's/^(.+) link:0*([1-9][0-9]*).*\[.*\]/\2=\1/p'
+fi

--- a/src/_adr_remove_status
+++ b/src/_adr_remove_status
@@ -6,22 +6,22 @@ current_status=${1:?FROM}
 file=$("$adr_bin_dir/_adr_file" "${2:?FILE}")
 
 awk -v current_status="$current_status" '
-	BEGIN { 
-		in_status_section=0 
+	BEGIN {
+		in_status_section=0
 	}
-	/^##/ { 
-		in_status_section=0 
+	/^[#=]{2}/ {
+		in_status_section=0
 	}
-	/^## Status$/ { 
-		in_status_section=1 
+	/^[#=]{2} Status$/ {
+		in_status_section=1
 	}
 	in_status_section && /^\s*$/ {
 		if (!after_blank) print
 		after_blank=1
 		next
 	}
-	in_status_section && $0 == current_status { 
-		next 
+	in_status_section && $0 == current_status {
+		next
 	}
 	in_status_section && ! /^\s*$/ {
 		after_blank=0

--- a/src/_adr_status
+++ b/src/_adr_status
@@ -3,7 +3,7 @@ set -e
 eval "$($(dirname $0)/adr-config)"
 
 awk '
-/^## Status/,/^#/ && !/^## Status/ { 
-	if (!/^(#|\s*$)/) print
+/^[#=]{2} Status/,/^[#=]/ && !/^[#=]{2} Status/ {
+	if (!/^([#=]|\s*$)/) print
 }
 ' "$("$adr_bin_dir/_adr_file" "$1")"

--- a/src/_adr_text_header
+++ b/src/_adr_text_header
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+eval "$($(dirname $0)/adr-config)"
+
+level=$1
+text="$2"
+file_type="$($adr_bin_dir/_adr_file_type)"
+
+if [ "$file_type" = "md" ]
+then
+  printf '#%.0s' {1..$level}
+else
+  printf '=%.0s' {1..$level}
+fi
+printf ' %s' "$text"

--- a/src/_adr_text_link
+++ b/src/_adr_text_link
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+eval "$($(dirname $0)/adr-config)"
+
+title="$1"
+link="$2"
+file_type="$($adr_bin_dir/_adr_file_type)"
+
+if [ "$file_type" = "md" ]
+then
+  printf "[%s](%s)" "$title" "$link"
+else
+  printf "link:%s[%s]" "$link" "$title"
+fi

--- a/src/adr-generate
+++ b/src/adr-generate
@@ -5,8 +5,8 @@ eval "$($(dirname $0)/adr-config)"
 ## usage: adr generate [REPORT [OPTION ...]]
 ##
 ## Generates summary documentation about the architecture decision records
-## that is typically fed into the tool chain for publishing a project's 
-## documentatation.
+## that is typically fed into the tool chain for publishing a project's
+## documentation.
 ##
 ## To list the report types that can be generated, run:
 ##
@@ -16,7 +16,7 @@ eval "$($(dirname $0)/adr-config)"
 ##
 ##     adr help generate <report-type>
 ##
-## For example, the following command will run the "toc" (table of contents) 
+## For example, the following command will run the "toc" (table of contents)
 ## generator:
 ##
 ##     adr generate toc

--- a/src/adr-init
+++ b/src/adr-init
@@ -2,21 +2,51 @@
 set -e
 eval "$($(dirname $0)/adr-config)"
 
-## usage: adr init [DIRECTORY]
-## 
+## usage: adr init [-t FILETYPE] [DIRECTORY]
+##
 ## Initialises the directory of architecture decision records:
-## 
+##
 ##  * creates a subdirectory of the current working directory
 ##  * creates the first ADR in that subdirectory, recording the decision to
 ##    record architectural decisions with ADRs.
 ##
 ## If the DIRECTORY is not given, the ADRs are stored in the directory `doc/adr`.
+##
+## Options:
+##
+## -t FILE_TYPE
+##                 Uses the specified file type.
+##                 FILE_TYPE is md (for markdown, default) or adoc (asciidoc).
+file_type='md'
 
+while getopts t: arg
+do
+    case "$arg" in
+		    t)
+		        if [ "$OPTARG" != "md" ] && [ "$OPTARG" != "adoc" ]
+		        then
+              echo "Unsupported file type: $OPTARG" >&2
+              exit 1
+		        fi
+			      file_type="$OPTARG"
+			      ;;
+        --)
+            break
+            ;;
+        *)
+            echo "Not implemented: $arg" >&2
+            exit 1
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+echo "$file_type" > .adr-file-type
 if [ ! -z $1 ]
 then
     mkdir -p "$1"
     echo "$1" > .adr-dir
 fi
 
-VISUAL=true ADR_TEMPLATE="$adr_template_dir/init.md" \
+VISUAL=true ADR_TEMPLATE="$adr_template_dir/init.$file_type" \
       "$adr_bin_dir/adr-new" record-architecture-decisions

--- a/src/adr-list
+++ b/src/adr-list
@@ -10,7 +10,7 @@ adr_dir=$("$adr_bin_dir/_adr_dir")
 
 if [ -d $adr_dir ]
 then
-   find $adr_dir | grep -E "^$adr_dir/[0-9]+-[^/]*\\.md" | sort
+   find $adr_dir | grep -E "^$adr_dir/[0-9]+-[^/]*\\.$adr_file_type" | sort
 else
     echo "The $adr_dir directory does not exist"
     exit 1

--- a/src/adr-new
+++ b/src/adr-new
@@ -11,7 +11,8 @@ eval "$($(dirname $0)/adr-config)"
 ## file name of the ADR is output to stdout, so the command can be used in
 ## scripts.
 ##
-## If the ADR directory contains a file `templates/template.md`, this is used as
+## If the ADR directory contains a file `templates/template.md` or
+## `templates/template.md` depending the project file type, this is used as
 ## the template for the new ADR.  Otherwise a default template is used that
 ## follows the style described by Michael Nygard in this article:
 ##
@@ -20,20 +21,20 @@ eval "$($(dirname $0)/adr-config)"
 ## Options:
 ##
 ## -s SUPERCEDED   A reference (number or partial filename) of a previous
-##                 decision that the new decision supercedes. A Markdown link
+##                 decision that the new decision supercedes. A link
 ##                 to the superceded ADR is inserted into the Status section.
 ##                 The status of the superceded ADR is changed to record that
 ##                 it has been superceded by the new ADR.
 ##
 ## -l TARGET:LINK:REVERSE-LINK
-##                 Links the new ADR to a previous ADR.  
-##                 TARGET is a reference (number or partial filename) of a 
-##                 previous decision. 
+##                 Links the new ADR to a previous ADR.
+##                 TARGET is a reference (number or partial filename) of a
+##                 previous decision.
 ##                 LINK is the description of the link created in the new ADR.
 ##                 REVERSE-LINK is the description of the link created in the
 ##                 existing ADR that will refer to the new ADR.
 ##
-## Multiple -s and -l options can be given, so that the new ADR can supercede 
+## Multiple -s and -l options can be given, so that the new ADR can supercede
 ## or link to multiple existing ADRs.
 ##
 ## E.g. to create a new ADR with the title "Use MySQL Database":
@@ -73,13 +74,14 @@ done
 shift $((OPTIND-1))
 
 dstdir=$("$adr_bin_dir/_adr_dir")
+file_type=$("$adr_bin_dir/_adr_file_type")
 template="$ADR_TEMPLATE"
 if [ -z $template ]
 then
-    template="$dstdir/templates/template.md"
+    template="$dstdir/templates/template.$file_type"
     if [ ! -f "$template" ]
     then
-        template="$adr_template_dir/template.md"
+        template="$adr_template_dir/template.$file_type"
     fi
 fi
 
@@ -101,7 +103,7 @@ fi
 
 newid=$(printf "%04d" $newnum)
 slug=$(echo -n $title | tr -Ccs [:alnum:] - | tr [:upper:] [:lower:] | sed -e 's/[^[:alnum:]]*$//' -e 's/^[^[:alnum:]]*//')
-dstfile=$dstdir/$newid-$slug.md
+dstfile=$dstdir/$newid-$slug.$file_type
 date=${ADR_DATE:-$(date +%Y-%m-%d)}
 
 mkdir -p $dstdir
@@ -124,7 +126,7 @@ do
 	target="$(echo $l | cut -d : -f 1)"
 	forward_link="$(echo $l | cut -d : -f 2)"
 	reverse_link="$(echo $l | cut -d : -f 3)"
-	
+
 	"$adr_bin_dir/_adr_add_link" "$dstfile" "$forward_link" "$target"
 	"$adr_bin_dir/_adr_add_link" "$target" "$reverse_link" "$dstfile"
 done

--- a/src/init.adoc
+++ b/src/init.adoc
@@ -1,0 +1,19 @@
+= 1. Record architecture decisions
+
+Date: DATE
+
+== Status
+
+Accepted
+
+== Context
+
+We need to record the architectural decisions made on this project.
+
+== Decision
+
+We will use Architecture Decision Records, as http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions[described by Michael Nygard].
+
+== Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's https://github.com/npryce/adr-tools[adr-tools].

--- a/src/template.adoc
+++ b/src/template.adoc
@@ -1,0 +1,19 @@
+= NUMBER. TITLE
+
+Date: DATE
+
+== Status
+
+STATUS
+
+== Context
+
+The issue motivating this decision, and any context that influences or constrains the decision.
+
+== Decision
+
+The change that we're proposing or have agreed to implement.
+
+== Consequences
+
+What becomes easier or more difficult to do and any risks introduced by the change that will need to be mitigated.

--- a/tests/asciidoc-alternative-adr-directory.expected
+++ b/tests/asciidoc-alternative-adr-directory.expected
@@ -1,0 +1,14 @@
+adr init -t adoc alternative-dir
+alternative-dir/0001-record-architecture-decisions.adoc
+adr new Example ADR
+alternative-dir/0002-example-adr.adoc
+
+ls .
+alternative-dir
+ls alternative-dir
+0001-record-architecture-decisions.adoc
+0002-example-adr.adoc
+
+adr list
+alternative-dir/0001-record-architecture-decisions.adoc
+alternative-dir/0002-example-adr.adoc

--- a/tests/asciidoc-alternative-adr-directory.sh
+++ b/tests/asciidoc-alternative-adr-directory.sh
@@ -1,0 +1,7 @@
+adr init -t adoc alternative-dir
+adr new Example ADR
+
+ls .
+ls alternative-dir
+
+adr list

--- a/tests/asciidoc-autocomplete.expected
+++ b/tests/asciidoc-autocomplete.expected
@@ -1,0 +1,10 @@
+_adr_autocomplete adr
+config generate help init link list new upgrade-repository
+_adr_autocomplete adr li
+link list
+_adr_autocomplete adr generate
+graph toc
+_adr_autocomplete adr generate to
+toc
+_adr_autocomplete adr ierhir
+

--- a/tests/asciidoc-autocomplete.sh
+++ b/tests/asciidoc-autocomplete.sh
@@ -1,0 +1,5 @@
+_adr_autocomplete adr
+_adr_autocomplete adr li
+_adr_autocomplete adr generate
+_adr_autocomplete adr generate to
+_adr_autocomplete adr ierhir

--- a/tests/asciidoc-avoid-octal-numbers.expected
+++ b/tests/asciidoc-avoid-octal-numbers.expected
@@ -1,0 +1,37 @@
+echo "adoc" > .adr-file-type
+adr new First Decision
+doc/adr/0001-first-decision.adoc
+adr new Second Decision
+doc/adr/0002-second-decision.adoc
+adr new Third Decision
+doc/adr/0003-third-decision.adoc
+adr new Fourth Decision
+doc/adr/0004-fourth-decision.adoc
+adr new Fifth Decision
+doc/adr/0005-fifth-decision.adoc
+adr new Sixth Decision
+doc/adr/0006-sixth-decision.adoc
+adr new Seventh Decision
+doc/adr/0007-seventh-decision.adoc
+adr new Eighth Decision
+doc/adr/0008-eighth-decision.adoc
+adr new Ninth Decision
+doc/adr/0009-ninth-decision.adoc
+ls doc/adr
+0001-first-decision.adoc
+0002-second-decision.adoc
+0003-third-decision.adoc
+0004-fourth-decision.adoc
+0005-fifth-decision.adoc
+0006-sixth-decision.adoc
+0007-seventh-decision.adoc
+0008-eighth-decision.adoc
+0009-ninth-decision.adoc
+head -7 doc/adr/0009-ninth-decision.adoc
+= 9. Ninth Decision
+
+Date: 1992-01-12
+
+== Status
+
+Accepted

--- a/tests/asciidoc-avoid-octal-numbers.sh
+++ b/tests/asciidoc-avoid-octal-numbers.sh
@@ -1,0 +1,12 @@
+echo "adoc" > .adr-file-type
+adr new First Decision
+adr new Second Decision
+adr new Third Decision
+adr new Fourth Decision
+adr new Fifth Decision
+adr new Sixth Decision
+adr new Seventh Decision
+adr new Eighth Decision
+adr new Ninth Decision
+ls doc/adr
+head -7 doc/adr/0009-ninth-decision.adoc

--- a/tests/asciidoc-create-first-record.expected
+++ b/tests/asciidoc-create-first-record.expected
@@ -1,0 +1,23 @@
+echo "adoc" > .adr-file-type
+adr new The First Decision
+doc/adr/0001-the-first-decision.adoc
+cat doc/adr/0001-the-first-decision.adoc
+= 1. The First Decision
+
+Date: 1992-01-12
+
+== Status
+
+Accepted
+
+== Context
+
+The issue motivating this decision, and any context that influences or constrains the decision.
+
+== Decision
+
+The change that we're proposing or have agreed to implement.
+
+== Consequences
+
+What becomes easier or more difficult to do and any risks introduced by the change that will need to be mitigated.

--- a/tests/asciidoc-create-first-record.sh
+++ b/tests/asciidoc-create-first-record.sh
@@ -1,0 +1,3 @@
+echo "adoc" > .adr-file-type
+adr new The First Decision
+cat doc/adr/0001-the-first-decision.adoc

--- a/tests/asciidoc-create-mutiple-records.expected
+++ b/tests/asciidoc-create-mutiple-records.expected
@@ -1,0 +1,27 @@
+echo "adoc" > .adr-file-type
+adr new First Decision
+doc/adr/0001-first-decision.adoc
+adr new Second Decision
+doc/adr/0002-second-decision.adoc
+adr new Third Decision
+doc/adr/0003-third-decision.adoc
+ls doc/adr
+0001-first-decision.adoc
+0002-second-decision.adoc
+0003-third-decision.adoc
+head -7 doc/adr/0002-second-decision.adoc
+= 2. Second Decision
+
+Date: 1992-01-12
+
+== Status
+
+Accepted
+head -7 doc/adr/0003-third-decision.adoc
+= 3. Third Decision
+
+Date: 1992-01-12
+
+== Status
+
+Accepted

--- a/tests/asciidoc-create-mutiple-records.sh
+++ b/tests/asciidoc-create-mutiple-records.sh
@@ -1,0 +1,7 @@
+echo "adoc" > .adr-file-type
+adr new First Decision
+adr new Second Decision
+adr new Third Decision
+ls doc/adr
+head -7 doc/adr/0002-second-decision.adoc
+head -7 doc/adr/0003-third-decision.adoc

--- a/tests/asciidoc-edit-adr-on-creation.expected
+++ b/tests/asciidoc-edit-adr-on-creation.expected
@@ -1,0 +1,21 @@
+echo "adoc" > .adr-file-type
+export EDITOR
+export VISUAL
+
+EDITOR=fake-editor
+VISUAL=
+adr new created with EDITOR environment variable set
+EDITOR doc/adr/0001-created-with-editor-environment-variable-set.adoc
+doc/adr/0001-created-with-editor-environment-variable-set.adoc
+
+EDITOR=
+VISUAL=fake-visual
+adr new created with VISUAL environment variable set
+VISUAL doc/adr/0002-created-with-visual-environment-variable-set.adoc
+doc/adr/0002-created-with-visual-environment-variable-set.adoc
+
+EDITOR=fake-editor
+VISUAL=fake-visual
+adr new uses setting of VISUAL if both VISUAL and EDITOR are set
+VISUAL doc/adr/0003-uses-setting-of-visual-if-both-visual-and-editor-are-set.adoc
+doc/adr/0003-uses-setting-of-visual-if-both-visual-and-editor-are-set.adoc

--- a/tests/asciidoc-edit-adr-on-creation.sh
+++ b/tests/asciidoc-edit-adr-on-creation.sh
@@ -1,0 +1,15 @@
+echo "adoc" > .adr-file-type
+export EDITOR
+export VISUAL
+
+EDITOR=fake-editor
+VISUAL=
+adr new created with EDITOR environment variable set
+
+EDITOR=
+VISUAL=fake-visual
+adr new created with VISUAL environment variable set
+
+EDITOR=fake-editor
+VISUAL=fake-visual
+adr new uses setting of VISUAL if both VISUAL and EDITOR are set

--- a/tests/asciidoc-funny-characters.expected
+++ b/tests/asciidoc-funny-characters.expected
@@ -1,0 +1,11 @@
+echo "adoc" > .adr-file-type
+adr new Something About Node.JS
+doc/adr/0001-something-about-node-js.adoc
+adr new Slash/Slash/Slash/
+doc/adr/0002-slash-slash-slash.adoc
+adr new -- "-Bar-"
+doc/adr/0003-bar.adoc
+ls doc/adr
+0001-something-about-node-js.adoc
+0002-slash-slash-slash.adoc
+0003-bar.adoc

--- a/tests/asciidoc-funny-characters.sh
+++ b/tests/asciidoc-funny-characters.sh
@@ -1,0 +1,5 @@
+echo "adoc" > .adr-file-type
+adr new Something About Node.JS
+adr new Slash/Slash/Slash/
+adr new -- "-Bar-"
+ls doc/adr

--- a/tests/asciidoc-generate-contents-with-header-and-footer.expected
+++ b/tests/asciidoc-generate-contents-with-header-and-footer.expected
@@ -1,0 +1,27 @@
+echo "adoc" > .adr-file-type
+adr new First Decision
+doc/adr/0001-first-decision.adoc
+adr new Second Decision
+doc/adr/0002-second-decision.adoc
+adr new Third Decision
+doc/adr/0003-third-decision.adoc
+cat > intro.adoc <<EOF
+An intro.
+
+Multiple paragraphs.
+EOF
+cat > outro.adoc <<EOF
+An outro.
+EOF
+adr generate toc -i intro.adoc -o outro.adoc
+= Architecture Decision Records
+
+An intro.
+
+Multiple paragraphs.
+
+* link:0001-first-decision.adoc[1. First Decision]
+* link:0002-second-decision.adoc[2. Second Decision]
+* link:0003-third-decision.adoc[3. Third Decision]
+
+An outro.

--- a/tests/asciidoc-generate-contents-with-header-and-footer.sh
+++ b/tests/asciidoc-generate-contents-with-header-and-footer.sh
@@ -1,0 +1,13 @@
+echo "adoc" > .adr-file-type
+adr new First Decision
+adr new Second Decision
+adr new Third Decision
+cat > intro.adoc <<EOF
+An intro.
+
+Multiple paragraphs.
+EOF
+cat > outro.adoc <<EOF
+An outro.
+EOF
+adr generate toc -i intro.adoc -o outro.adoc

--- a/tests/asciidoc-generate-contents-with-prefix.expected
+++ b/tests/asciidoc-generate-contents-with-prefix.expected
@@ -1,0 +1,13 @@
+echo "adoc" > .adr-file-type
+adr new First Decision
+doc/adr/0001-first-decision.adoc
+adr new Second Decision
+doc/adr/0002-second-decision.adoc
+adr new Third Decision
+doc/adr/0003-third-decision.adoc
+adr generate toc -p foo/doc/adr/
+= Architecture Decision Records
+
+* link:foo/doc/adr/0001-first-decision.adoc[1. First Decision]
+* link:foo/doc/adr/0002-second-decision.adoc[2. Second Decision]
+* link:foo/doc/adr/0003-third-decision.adoc[3. Third Decision]

--- a/tests/asciidoc-generate-contents-with-prefix.sh
+++ b/tests/asciidoc-generate-contents-with-prefix.sh
@@ -1,0 +1,5 @@
+echo "adoc" > .adr-file-type
+adr new First Decision
+adr new Second Decision
+adr new Third Decision
+adr generate toc -p foo/doc/adr/

--- a/tests/asciidoc-generate-contents.expected
+++ b/tests/asciidoc-generate-contents.expected
@@ -1,0 +1,13 @@
+echo "adoc" > .adr-file-type
+adr new First Decision
+doc/adr/0001-first-decision.adoc
+adr new Second Decision
+doc/adr/0002-second-decision.adoc
+adr new Third Decision
+doc/adr/0003-third-decision.adoc
+adr generate toc
+= Architecture Decision Records
+
+* link:0001-first-decision.adoc[1. First Decision]
+* link:0002-second-decision.adoc[2. Second Decision]
+* link:0003-third-decision.adoc[3. Third Decision]

--- a/tests/asciidoc-generate-contents.sh
+++ b/tests/asciidoc-generate-contents.sh
@@ -1,0 +1,5 @@
+echo "adoc" > .adr-file-type
+adr new First Decision
+adr new Second Decision
+adr new Third Decision
+adr generate toc

--- a/tests/asciidoc-generate-graph.expected
+++ b/tests/asciidoc-generate-graph.expected
@@ -1,0 +1,46 @@
+adr init -t adoc
+doc/adr/0001-record-architecture-decisions.adoc
+adr new An idea that seems good at the time
+doc/adr/0002-an-idea-that-seems-good-at-the-time.adoc
+adr new -s 2 A better idea
+doc/adr/0003-a-better-idea.adoc
+adr new This will work
+doc/adr/0004-this-will-work.adoc
+adr new -s 3 The end
+doc/adr/0005-the-end.adoc
+# with default root and extension in links
+adr generate graph
+digraph {
+  node [shape=plaintext];
+  subgraph {
+    _1 [label="1. Record architecture decisions"; URL="0001-record-architecture-decisions.html"];
+    _2 [label="2. An idea that seems good at the time"; URL="0002-an-idea-that-seems-good-at-the-time.html"];
+    _1 -> _2 [style="dotted", weight=1];
+    _3 [label="3. A better idea"; URL="0003-a-better-idea.html"];
+    _2 -> _3 [style="dotted", weight=1];
+    _4 [label="4. This will work"; URL="0004-this-will-work.html"];
+    _3 -> _4 [style="dotted", weight=1];
+    _5 [label="5. The end"; URL="0005-the-end.html"];
+    _4 -> _5 [style="dotted", weight=1];
+  }
+  _3 -> _2 [label="Supercedes", weight=0]
+  _5 -> _3 [label="Supercedes", weight=0]
+}
+# with specified root and extension in links
+adr generate graph -p http://example.com/ -e .xxx
+digraph {
+  node [shape=plaintext];
+  subgraph {
+    _1 [label="1. Record architecture decisions"; URL="http://example.com/0001-record-architecture-decisions.xxx"];
+    _2 [label="2. An idea that seems good at the time"; URL="http://example.com/0002-an-idea-that-seems-good-at-the-time.xxx"];
+    _1 -> _2 [style="dotted", weight=1];
+    _3 [label="3. A better idea"; URL="http://example.com/0003-a-better-idea.xxx"];
+    _2 -> _3 [style="dotted", weight=1];
+    _4 [label="4. This will work"; URL="http://example.com/0004-this-will-work.xxx"];
+    _3 -> _4 [style="dotted", weight=1];
+    _5 [label="5. The end"; URL="http://example.com/0005-the-end.xxx"];
+    _4 -> _5 [style="dotted", weight=1];
+  }
+  _3 -> _2 [label="Supercedes", weight=0]
+  _5 -> _3 [label="Supercedes", weight=0]
+}

--- a/tests/asciidoc-generate-graph.sh
+++ b/tests/asciidoc-generate-graph.sh
@@ -1,0 +1,9 @@
+adr init -t adoc
+adr new An idea that seems good at the time
+adr new -s 2 A better idea
+adr new This will work
+adr new -s 3 The end
+# with default root and extension in links
+adr generate graph
+# with specified root and extension in links
+adr generate graph -p http://example.com/ -e .xxx

--- a/tests/asciidoc-init-adr-repository.expected
+++ b/tests/asciidoc-init-adr-repository.expected
@@ -1,0 +1,24 @@
+adr init -t adoc
+doc/adr/0001-record-architecture-decisions.adoc
+ls doc/adr
+0001-record-architecture-decisions.adoc
+cat doc/adr/0001-record-architecture-decisions.adoc
+= 1. Record architecture decisions
+
+Date: 1992-01-12
+
+== Status
+
+Accepted
+
+== Context
+
+We need to record the architectural decisions made on this project.
+
+== Decision
+
+We will use Architecture Decision Records, as http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions[described by Michael Nygard].
+
+== Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's https://github.com/npryce/adr-tools[adr-tools].

--- a/tests/asciidoc-init-adr-repository.sh
+++ b/tests/asciidoc-init-adr-repository.sh
@@ -1,0 +1,3 @@
+adr init -t adoc
+ls doc/adr
+cat doc/adr/0001-record-architecture-decisions.adoc

--- a/tests/asciidoc-linking-new-records.expected
+++ b/tests/asciidoc-linking-new-records.expected
@@ -1,0 +1,48 @@
+echo "adoc" > .adr-file-type
+adr new First Record
+doc/adr/0001-first-record.adoc
+adr new Second Record
+doc/adr/0002-second-record.adoc
+adr new -l "1:Amends:Amended by" -l "2:Clarifies:Clarified by" Third Record
+doc/adr/0003-third-record.adoc
+head -12 doc/adr/0001-first-record.adoc
+= 1. First Record
+
+Date: 1992-01-12
+
+== Status
+
+Accepted
+
+Amended by link:0003-third-record.adoc[3. Third Record]
+
+== Context
+
+head -12 doc/adr/0002-second-record.adoc
+= 2. Second Record
+
+Date: 1992-01-12
+
+== Status
+
+Accepted
+
+Clarified by link:0003-third-record.adoc[3. Third Record]
+
+== Context
+
+head -14 doc/adr/0003-third-record.adoc
+= 3. Third Record
+
+Date: 1992-01-12
+
+== Status
+
+Accepted
+
+Amends link:0001-first-record.adoc[1. First Record]
+
+Clarifies link:0002-second-record.adoc[2. Second Record]
+
+== Context
+

--- a/tests/asciidoc-linking-new-records.sh
+++ b/tests/asciidoc-linking-new-records.sh
@@ -1,0 +1,7 @@
+echo "adoc" > .adr-file-type
+adr new First Record
+adr new Second Record
+adr new -l "1:Amends:Amended by" -l "2:Clarifies:Clarified by" Third Record
+head -12 doc/adr/0001-first-record.adoc
+head -12 doc/adr/0002-second-record.adoc
+head -14 doc/adr/0003-third-record.adoc

--- a/tests/asciidoc-linking.expected
+++ b/tests/asciidoc-linking.expected
@@ -1,0 +1,50 @@
+echo "adoc" > .adr-file-type
+adr new First Record
+doc/adr/0001-first-record.adoc
+adr new Second Record
+doc/adr/0002-second-record.adoc
+adr new Third Record
+doc/adr/0003-third-record.adoc
+adr link 3 Amends 1 "Amended by"
+adr link 3 Clarifies 2 "Clarified by"
+head -12 doc/adr/0001-first-record.adoc
+= 1. First Record
+
+Date: 1992-01-12
+
+== Status
+
+Accepted
+
+Amended by link:0003-third-record.adoc[3. Third Record]
+
+== Context
+
+head -12 doc/adr/0002-second-record.adoc
+= 2. Second Record
+
+Date: 1992-01-12
+
+== Status
+
+Accepted
+
+Clarified by link:0003-third-record.adoc[3. Third Record]
+
+== Context
+
+head -14 doc/adr/0003-third-record.adoc
+= 3. Third Record
+
+Date: 1992-01-12
+
+== Status
+
+Accepted
+
+Amends link:0001-first-record.adoc[1. First Record]
+
+Clarifies link:0002-second-record.adoc[2. Second Record]
+
+== Context
+

--- a/tests/asciidoc-linking.sh
+++ b/tests/asciidoc-linking.sh
@@ -1,0 +1,9 @@
+echo "adoc" > .adr-file-type
+adr new First Record
+adr new Second Record
+adr new Third Record
+adr link 3 Amends 1 "Amended by"
+adr link 3 Clarifies 2 "Clarified by"
+head -12 doc/adr/0001-first-record.adoc
+head -12 doc/adr/0002-second-record.adoc
+head -14 doc/adr/0003-third-record.adoc

--- a/tests/asciidoc-list-records.expected
+++ b/tests/asciidoc-list-records.expected
@@ -1,0 +1,19 @@
+echo "adoc" > .adr-file-type
+adr list
+The doc/adr directory does not exist
+adr new first
+doc/adr/0001-first.adoc
+adr list
+doc/adr/0001-first.adoc
+adr new second
+doc/adr/0002-second.adoc
+adr list
+doc/adr/0001-first.adoc
+doc/adr/0002-second.adoc
+adr new third
+doc/adr/0003-third.adoc
+adr list
+doc/adr/0001-first.adoc
+doc/adr/0002-second.adoc
+doc/adr/0003-third.adoc
+

--- a/tests/asciidoc-list-records.sh
+++ b/tests/asciidoc-list-records.sh
@@ -1,0 +1,9 @@
+echo "adoc" > .adr-file-type
+adr list
+adr new first
+adr list
+adr new second
+adr list
+adr new third
+adr list
+

--- a/tests/asciidoc-migrate-date-format.expected
+++ b/tests/asciidoc-migrate-date-format.expected
@@ -1,0 +1,18 @@
+adr init -t adoc
+doc/adr/0001-record-architecture-decisions.adoc
+(
+	ADR_DATE=12/01/1992
+	adr new With Old Date Format
+)
+doc/adr/0002-with-old-date-format.adoc
+adr new With Current Date Format
+doc/adr/0003-with-current-date-format.adoc
+grep Date: doc/adr/*
+doc/adr/0001-record-architecture-decisions.adoc:Date: 1992-01-12
+doc/adr/0002-with-old-date-format.adoc:Date: 12/01/1992
+doc/adr/0003-with-current-date-format.adoc:Date: 1992-01-12
+adr upgrade-repository
+grep Date: doc/adr/*
+doc/adr/0001-record-architecture-decisions.adoc:Date: 1992-01-12
+doc/adr/0002-with-old-date-format.adoc:Date: 1992-01-12
+doc/adr/0003-with-current-date-format.adoc:Date: 1992-01-12

--- a/tests/asciidoc-migrate-date-format.sh
+++ b/tests/asciidoc-migrate-date-format.sh
@@ -1,0 +1,9 @@
+adr init -t adoc
+(
+	ADR_DATE=12/01/1992
+	adr new With Old Date Format
+)
+adr new With Current Date Format
+grep Date: doc/adr/*
+adr upgrade-repository
+grep Date: doc/adr/*

--- a/tests/asciidoc-project-specific-template.expected
+++ b/tests/asciidoc-project-specific-template.expected
@@ -1,0 +1,53 @@
+adr init -t adoc adrs
+adrs/0001-record-architecture-decisions.adoc
+mkdir -p adrs/templates
+cat > adrs/templates/template.adoc <<EOF
+= TITLE
+
+Project specific template!
+
+= Status
+
+STATUS
+
+= Info
+
+ADR Number: NUMBER
+
+Date: DATE
+
+EOF
+adr new Aaa Bbb
+adrs/0002-aaa-bbb.adoc
+adr new Ccc Ddd
+adrs/0003-ccc-ddd.adoc
+cat adrs/0002-aaa-bbb.adoc
+= Aaa Bbb
+
+Project specific template!
+
+= Status
+
+Accepted
+
+= Info
+
+ADR Number: 2
+
+Date: 1992-01-12
+
+cat adrs/0003-ccc-ddd.adoc
+= Ccc Ddd
+
+Project specific template!
+
+= Status
+
+Accepted
+
+= Info
+
+ADR Number: 3
+
+Date: 1992-01-12
+

--- a/tests/asciidoc-project-specific-template.sh
+++ b/tests/asciidoc-project-specific-template.sh
@@ -1,0 +1,22 @@
+adr init -t adoc adrs
+mkdir -p adrs/templates
+cat > adrs/templates/template.adoc <<EOF
+= TITLE
+
+Project specific template!
+
+= Status
+
+STATUS
+
+= Info
+
+ADR Number: NUMBER
+
+Date: DATE
+
+EOF
+adr new Aaa Bbb
+adr new Ccc Ddd
+cat adrs/0002-aaa-bbb.adoc
+cat adrs/0003-ccc-ddd.adoc

--- a/tests/asciidoc-search-for-adr-dir.expected
+++ b/tests/asciidoc-search-for-adr-dir.expected
@@ -1,0 +1,14 @@
+echo "adoc" > .adr-file-type
+adr new First Record
+doc/adr/0001-first-record.adoc
+mkdir subdir
+cd subdir
+adr new Second Record
+../doc/adr/0002-second-record.adoc
+adr list
+../doc/adr/0001-first-record.adoc
+../doc/adr/0002-second-record.adoc
+cd ..
+adr list
+doc/adr/0001-first-record.adoc
+doc/adr/0002-second-record.adoc

--- a/tests/asciidoc-search-for-adr-dir.sh
+++ b/tests/asciidoc-search-for-adr-dir.sh
@@ -1,0 +1,8 @@
+echo "adoc" > .adr-file-type
+adr new First Record
+mkdir subdir
+cd subdir
+adr new Second Record
+adr list
+cd ..
+adr list

--- a/tests/asciidoc-search-for-custom-adr-dir.expected
+++ b/tests/asciidoc-search-for-custom-adr-dir.expected
@@ -1,0 +1,17 @@
+adr init -t adoc architecture-log
+architecture-log/0001-record-architecture-decisions.adoc
+adr new First Record
+architecture-log/0002-first-record.adoc
+mkdir subdir
+cd subdir
+adr new Second Record
+../architecture-log/0003-second-record.adoc
+adr list
+../architecture-log/0001-record-architecture-decisions.adoc
+../architecture-log/0002-first-record.adoc
+../architecture-log/0003-second-record.adoc
+cd ..
+adr list
+architecture-log/0001-record-architecture-decisions.adoc
+architecture-log/0002-first-record.adoc
+architecture-log/0003-second-record.adoc

--- a/tests/asciidoc-search-for-custom-adr-dir.sh
+++ b/tests/asciidoc-search-for-custom-adr-dir.sh
@@ -1,0 +1,8 @@
+adr init -t adoc architecture-log
+adr new First Record
+mkdir subdir
+cd subdir
+adr new Second Record
+adr list
+cd ..
+adr list

--- a/tests/asciidoc-supercede-existing-adr.expected
+++ b/tests/asciidoc-supercede-existing-adr.expected
@@ -1,0 +1,30 @@
+echo "adoc" > .adr-file-type
+adr new First Record
+doc/adr/0001-first-record.adoc
+adr new -s 1 Second Record
+doc/adr/0002-second-record.adoc
+head -10 doc/adr/0001-first-record.adoc
+= 1. First Record
+
+Date: 1992-01-12
+
+== Status
+
+Superceded by link:0002-second-record.adoc[2. Second Record]
+
+== Context
+
+head -12 doc/adr/0002-second-record.adoc
+= 2. Second Record
+
+Date: 1992-01-12
+
+== Status
+
+Accepted
+
+Supercedes link:0001-first-record.adoc[1. First Record]
+
+== Context
+
+

--- a/tests/asciidoc-supercede-existing-adr.sh
+++ b/tests/asciidoc-supercede-existing-adr.sh
@@ -1,0 +1,6 @@
+echo "adoc" > .adr-file-type
+adr new First Record
+adr new -s 1 Second Record
+head -10 doc/adr/0001-first-record.adoc
+head -12 doc/adr/0002-second-record.adoc
+

--- a/tests/asciidoc-supercede-multiple-adrs.expected
+++ b/tests/asciidoc-supercede-multiple-adrs.expected
@@ -1,0 +1,38 @@
+echo "adoc" > .adr-file-type
+adr new First Record
+doc/adr/0001-first-record.adoc
+adr new Second Record
+doc/adr/0002-second-record.adoc
+adr new -s 1 -s 2 Third Record
+doc/adr/0003-third-record.adoc
+head -8 doc/adr/0001-first-record.adoc
+= 1. First Record
+
+Date: 1992-01-12
+
+== Status
+
+Superceded by link:0003-third-record.adoc[3. Third Record]
+
+head -8 doc/adr/0002-second-record.adoc
+= 2. Second Record
+
+Date: 1992-01-12
+
+== Status
+
+Superceded by link:0003-third-record.adoc[3. Third Record]
+
+head -12 doc/adr/0003-third-record.adoc
+= 3. Third Record
+
+Date: 1992-01-12
+
+== Status
+
+Accepted
+
+Supercedes link:0001-first-record.adoc[1. First Record]
+
+Supercedes link:0002-second-record.adoc[2. Second Record]
+

--- a/tests/asciidoc-supercede-multiple-adrs.sh
+++ b/tests/asciidoc-supercede-multiple-adrs.sh
@@ -1,0 +1,7 @@
+echo "adoc" > .adr-file-type
+adr new First Record
+adr new Second Record
+adr new -s 1 -s 2 Third Record
+head -8 doc/adr/0001-first-record.adoc
+head -8 doc/adr/0002-second-record.adoc
+head -12 doc/adr/0003-third-record.adoc


### PR DESCRIPTION
This implements issue #73: provide the choice of the file format when initialising ADR log.

I added the `-t` option to `adr init` that stores in the `.adr-file-type` file the chosen format (markdown by default). Format values can be `md` for Markdown or `adoc` for AsciiDoc.

I duplicated all tests (except the one that checks a title is given to `adr new`) to ensure AsciiDoc is managed properly.

I didn't managed hybrid logs (containing MarkDown and AsciiDoc), nor migration from MarkDown to AsciiDoc. The migration could be handled via documentation by creating manually `.adr-file-type` file and running [Kramdoc](https://github.com/asciidoctor/kramdown-asciidoc) or [Pandoc](https://matthewsetter.com/convert-markdown-to-asciidoc-withpandoc/).

My bash is far from perfect, can anyone look at this PR?

Thanks



