### PR TITLE
Resolving Shellcheck SD2086 and SC2046

### DIFF
--- a/src/_adr_add_link
+++ b/src/_adr_add_link
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 source=$("$adr_bin_dir/_adr_file" "${1:?SOURCE}")
 link_type="${2:?LINK TYPE}"
@@ -8,7 +8,7 @@ target=$("$adr_bin_dir/_adr_file" "${3:?TARGET}")
 
 target_title="$("$adr_bin_dir/_adr_title" "$target")"
 
-awk -v link_type="$link_type" -v target="$(basename $target)" -v target_title="$target_title" '
+awk -v link_type="$link_type" -v target="$(basename "$target")" -v target_title="$target_title" '
 	BEGIN { 
 		in_status_section=0
 	}

--- a/src/_adr_autocomplete
+++ b/src/_adr_autocomplete
@@ -1,5 +1,5 @@
 #!/bin/bash
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 cmds=("$@")
 available_commands=$( $adr_bin_dir/_adr_commands | sort )
@@ -19,7 +19,7 @@ if (( ${#subcmds_files} > 0 ))
 then
   subcmds=$( for f in "${subcmds_files[@]}"
   do
-    basename $f | cut -c $(( ${#2} + 7 ))-
+    basename "$f" | cut -c $(( ${#2} + 7 ))-
   done )
   suggestions=($( compgen -W "${subcmds}" -- "$3" ))
   if [ "$suggestions" != "$3" ]

--- a/src/_adr_commands
+++ b/src/_adr_commands
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 for f in $(cd "$adr_bin_dir" && find . -name 'adr-*')
 do

--- a/src/_adr_dir
+++ b/src/_adr_dir
@@ -1,30 +1,30 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 reldir=.
 
 function mkrel() {
-	local d=$reldir/$1
-	echo ${d#./}
+	local d="$reldir/$1"
+	echo "${d#./}"
 }
 
 function absdir() {
-	(cd $(dirname $1) && pwd -P)
+	(cd "$(dirname "$1")" && pwd -P)
 }
 
-while [ $(absdir $reldir) != / ]
+while [ "$(absdir "$reldir")" != / ]
 do
-	if [ -f $(mkrel .adr-dir) ]
+	if [ -f "$(mkrel .adr-dir)" ]
 	then
-	    mkrel $(cat $(mkrel .adr-dir))
+	    mkrel "$(cat "$(mkrel .adr-dir)")"
 		exit
-	elif [ -d $(mkrel doc/adr) ] 
+	elif [ -d "$(mkrel doc/adr)" ]
 	then
 		mkrel doc/adr
 		exit
 	else
-		reldir=$reldir/..
+		reldir="$reldir/.."
 	fi
 done
 echo doc/adr

--- a/src/_adr_dir
+++ b/src/_adr_dir
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-eval "$("$(dirname "$0")/adr-config")"
 
 reldir=.
 

--- a/src/_adr_file
+++ b/src/_adr_file
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 "$adr_bin_dir/adr-list" | grep "$1" | head -1

--- a/src/_adr_generate_graph
+++ b/src/_adr_generate_graph
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 ## usage: adr generate graph [-p LINK_PREFIX] [-e LINK-EXTENSION]
 ##
@@ -61,10 +61,10 @@ echo "  subgraph {"
 for f in $("$adr_bin_dir/adr-list")
 do
 	n=$(index "$f")
-	title=$("$adr_bin_dir/_adr_title" $f)
+	title="$("$adr_bin_dir/_adr_title" "$f")"
 	
-	echo "    _$n [label=\"$title\"; URL=\"${link_prefix}$(basename $f .md)${link_extension}\"];"
-	if [ $n -gt 1 ]
+	echo "    _$n [label=\"$title\"; URL=\"${link_prefix}$(basename "$f" .md)${link_extension}\"];"
+	if [ "$n" -gt 1 ]
 	then
 		echo "    _$(($n - 1)) -> _$n [style=\"dotted\", weight=1];"
 	fi

--- a/src/_adr_generate_toc
+++ b/src/_adr_generate_toc
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 ## usage: adr generate toc [-i INTRO] [-o OUTRO] [-p LINK_PREFIX]
 ##
@@ -15,30 +15,19 @@ eval "$($(dirname $0)/adr-config)"
 ##
 ## Both INTRO and OUTRO must be in Markdown format.
 
-args=$(getopt i:o:p: $*)
-set -- $args
-
 link_prefix=
 
-for arg
+while getopts i:o:p: arg
 do
-    case "$arg"
-    in
-        -i)
-            intro="$2"
-            shift 2
+    case "$arg" in
+        i)
+            intro="$OPTARG"
             ;;
-        -o)
-            outro="$2"
-            shift 2
+        o)
+            outro="$OPTARG"
             ;;
-        -p)
-            link_prefix="$2"
-            shift 2
-            ;;
-        --)
-            shift
-            break
+        p)
+            link_prefix="$OPTARG"
             ;;
     esac
 done
@@ -48,7 +37,7 @@ cat <<EOF
 
 EOF
 
-if [ ! -z $intro ]
+if [ ! -z "$intro" ]
 then
     cat "$intro"
     echo
@@ -56,13 +45,13 @@ fi
 
 for f in $("$adr_bin_dir/adr-list")
 do
-    title=$("$adr_bin_dir/_adr_title" $f)
-    link=${link_prefix}$(basename $f)
+    title=$("$adr_bin_dir/_adr_title" "$f")
+    link=${link_prefix}$(basename "$f")
 
     echo "* [$title]($link)"
 done
 
-if [ ! -z $outro ]
+if [ ! -z "$outro" ]
 then
     echo
     cat "$outro"

--- a/src/_adr_help
+++ b/src/_adr_help
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 cmds=("$@")
 
@@ -18,7 +18,7 @@ if [ -z "$cmds" -o \( ! -x "$cmdexe" -a ! -x "$helpexe" \) ]
 then
     echo "usage: adr help COMMAND [ARG] ..."
     echo "COMMAND is one of: "
-    $adr_bin_dir/_adr_commands | sed 's/^/  /'
+    "$adr_bin_dir/_adr_commands" | sed 's/^/  /'
     echo "Run 'adr help COMMAND' for help on a specific command."
 else
 	if [ -x "$helpexe" ]
@@ -37,7 +37,7 @@ else
 		echo Subcommands:
 		for f in "${subcmds[@]}"
 		do
-			basename $f | cut -c $(( ${#1} + 7 ))-
+			basename "$f" | cut -c $(( ${#1} + 7 ))-
 		done | sed "s/^/  adr $1 /"
 	fi
 fi

--- a/src/_adr_help_new
+++ b/src/_adr_help_new
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 cat <<ENDHELP
 usage: adr new [-s SUPERCEDED] [-l TARGET:LINK:REVERSE-LINK] TITLE_TEXT...

--- a/src/_adr_links
+++ b/src/_adr_links
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 "$adr_bin_dir/_adr_status" "$1" | sed -n -E 's/^(.+) \[.*\]\(0*([1-9][0-9]*).*\)/\2=\1/p'

--- a/src/_adr_remove_status
+++ b/src/_adr_remove_status
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 current_status=${1:?FROM}
 file=$("$adr_bin_dir/_adr_file" "${2:?FILE}")

--- a/src/_adr_status
+++ b/src/_adr_status
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 awk '
 /^## Status/,/^#/ && !/^## Status/ { 

--- a/src/_adr_title
+++ b/src/_adr_title
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
-head -1 $("$adr_bin_dir/_adr_file" "$1") | cut -c 3-
+head -1 "$("$adr_bin_dir/_adr_file" "$1")" | cut -c 3-

--- a/src/adr
+++ b/src/adr
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
-cmd=$adr_bin_dir/adr-$1
+cmd="$adr_bin_dir/adr-$1"
 
-if [ -x $cmd ]
+if [ -x "$cmd" ]
 then
-    $cmd "${@:2}"
+    "$cmd" "${@:2}"
 else
-    $adr_bin_dir/adr-help
+    "$adr_bin_dir/adr-help"
     exit 1
 fi

--- a/src/adr-config
+++ b/src/adr-config
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Config for when running from the source directory.
 
-basedir=$(cd -L $(dirname $0) >/dev/null 2>&1 && pwd -L)
+basedir="$(cd -L "$(dirname "$0")" >/dev/null 2>&1 && pwd -L)"
 
 echo 'adr_bin_dir="'"${basedir}"'"'
 echo 'adr_template_dir="'"${basedir}"'"'

--- a/src/adr-generate
+++ b/src/adr-generate
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 ## usage: adr generate [REPORT [OPTION ...]]
 ##
@@ -25,9 +25,9 @@ eval "$($(dirname $0)/adr-config)"
 ##
 ##     adr help generate toc
 
-cmd=$1
+cmd="$1"
 
-if [ -z $cmd ]
+if [ -z "$cmd" ]
 then
     (cd "$adr_bin_dir" && find . -name '_adr_generate_*') | cut -c 17-
 else

--- a/src/adr-help
+++ b/src/adr-help
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 ## usage: adr help [COMMAND [SUBCOMMAND...]]
 ##
@@ -13,4 +13,4 @@ eval "$($(dirname $0)/adr-config)"
 
 pager="${ADR_PAGER:-${PAGER:-more}}"
 
-("$adr_bin_dir/_adr_help" "$@") | $pager
+("$adr_bin_dir/_adr_help" "$@") | "$pager"

--- a/src/adr-init
+++ b/src/adr-init
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 ## usage: adr init [DIRECTORY]
 ## 
@@ -12,7 +12,7 @@ eval "$($(dirname $0)/adr-config)"
 ##
 ## If the DIRECTORY is not given, the ADRs are stored in the directory `doc/adr`.
 
-if [ ! -z $1 ]
+if [ ! -z "$1" ]
 then
     mkdir -p "$1"
     echo "$1" > .adr-dir

--- a/src/adr-link
+++ b/src/adr-link
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 ## usage: adr link SOURCE LINK TARGET REVERSE-LINK
 ##

--- a/src/adr-list
+++ b/src/adr-list
@@ -1,16 +1,16 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 ## usage: adr list
 ##
 ## Lists the architecture decision records
 
-adr_dir=$("$adr_bin_dir/_adr_dir")
+adr_dir="$("$adr_bin_dir/_adr_dir")"
 
-if [ -d $adr_dir ]
+if [ -d "$adr_dir" ]
 then
-   find $adr_dir | grep -E "^$adr_dir/[0-9]+-[^/]*\\.md" | sort
+   find "$adr_dir" | grep -E "^$adr_dir/[0-9]+-[^/]*\\.md" | sort
 else
     echo "The $adr_dir directory does not exist"
     exit 1

--- a/src/adr-new
+++ b/src/adr-new
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 ## usage: adr new [-s SUPERCEDED] [-l TARGET:LINK:REVERSE-LINK] TITLE_TEXT...
 ##
@@ -72,9 +72,9 @@ do
 done
 shift $((OPTIND-1))
 
-dstdir=$("$adr_bin_dir/_adr_dir")
+dstdir="$("$adr_bin_dir/_adr_dir")"
 template="$ADR_TEMPLATE"
-if [ -z $template ]
+if [ -z "$template" ]
 then
     template="$dstdir/templates/template.md"
     if [ ! -f "$template" ]
@@ -91,26 +91,26 @@ then
     exit 1
 fi
 
-if [ -d $dstdir ]
+if [ -d "$dstdir" ]
 then
-    maxid=$(ls $dstdir | grep -Eo '^[0-9]+' | sed -e 's/^0*//' | sort -rn | head -1)
+    maxid=$(ls "$dstdir" | grep -Eo '^[0-9]+' | sed -e 's/^0*//' | sort -rn | head -1)
     newnum=$(($maxid + 1))
 else
     newnum=1
 fi
 
 newid=$(printf "%04d" $newnum)
-slug=$(echo -n $title | tr -Ccs [:alnum:] - | tr [:upper:] [:lower:] | sed -e 's/[^[:alnum:]]*$//' -e 's/^[^[:alnum:]]*//')
-dstfile=$dstdir/$newid-$slug.md
-date=${ADR_DATE:-$(date +%Y-%m-%d)}
+slug=$(echo -n "$title" | tr -Ccs "[:alnum:]" - | tr "[:upper:]" "[:lower:]" | sed -e 's/[^[:alnum:]]*$//' -e 's/^[^[:alnum:]]*//')
+dstfile="$dstdir/$newid-$slug.md"
+date="${ADR_DATE:-$(date +%Y-%m-%d)}"
 
-mkdir -p $dstdir
-cat $template | sed \
+mkdir -p "$dstdir"
+cat "$template" | sed \
     -e "s|NUMBER|$newnum|" \
     -e "s|TITLE|$title|" \
     -e "s|DATE|$date|" \
     -e "s|STATUS|Accepted|" \
-    > $dstfile
+    > "$dstfile"
 
 for target in "${superceded[@]}"
 do
@@ -121,13 +121,13 @@ done
 
 for l in "${links[@]}"
 do
-	target="$(echo $l | cut -d : -f 1)"
-	forward_link="$(echo $l | cut -d : -f 2)"
-	reverse_link="$(echo $l | cut -d : -f 3)"
+	target="$(echo "$l" | cut -d : -f 1)"
+	forward_link="$(echo "$l" | cut -d : -f 2)"
+	reverse_link="$(echo "$l" | cut -d : -f 3)"
 	
 	"$adr_bin_dir/_adr_add_link" "$dstfile" "$forward_link" "$target"
 	"$adr_bin_dir/_adr_add_link" "$target" "$reverse_link" "$dstfile"
 done
 
-${VISUAL:-${EDITOR:-true}} $dstfile
-echo $dstfile
+"${VISUAL:-${EDITOR:-true}}" "$dstfile"
+echo "$dstfile"

--- a/src/adr-upgrade-repository
+++ b/src/adr-upgrade-repository
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")/adr-config")"
 
 ## usage: adr upgrade-repository
 ##


### PR DESCRIPTION
Shellcheck results [SC2046](https://www.shellcheck.net/wiki/SC2046) and [SC2086](https://www.shellcheck.net/wiki/SC2086) relate to how variables are handled where they may hold strings with spaces or "glob"ing characters (like `*` and `?`).

In this PR, I wrap all script or function calls which pass variables that are themselves variables (`$foo`), or commands (`$(foo)`).

Note that this broke the test for generate-contents-with-prefix, so I resolved that by changing `getopt $*` to `getopts` in `src/_adr_generate_toc`.

This also removes the unnecesary loading of the config file in `_adr_dir`.