### PR TITLE
Allow system, global and local config, similar to how git configs are loaded

### DIFF
--- a/src/_adr_dir
+++ b/src/_adr_dir
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
 
 reldir=.
 

--- a/src/adr-config
+++ b/src/adr-config
@@ -3,5 +3,60 @@
 
 basedir=$(cd -L $(dirname $0) >/dev/null 2>&1 && pwd -L)
 
-echo 'adr_bin_dir="'"${basedir}"'"'
-echo 'adr_template_dir="'"${basedir}"'"'
+adr_bin_dir="$basedir"
+adr_template_dir="$basedir"
+
+quiet=0
+
+while getopts q arg
+do
+    case "$arg" in
+      q)
+        quiet=1
+        ;;
+      *)
+        echo "Not implemented: $arg" >&2
+        exit 1
+        ;;
+    esac
+done
+
+if [ "$quiet" -eq 0 ]
+then
+  echo "# This script returns the configuration values for adr-tools. It does not change these values."
+fi
+if [ -e /etc/default/adr-config ]
+then
+  if [ "$quiet" -eq 0 ]
+  then
+    echo "# Loading system values from /etc/default/adr-config"
+  fi
+  source /etc/default/adr-config
+fi
+if [ -e /etc/adr-config ]
+then
+  if [ "$quiet" -eq 0 ]
+  then
+      echo "# Loading system values from /etc/adr-config"
+  fi
+  source /etc/adr-config
+fi
+if [ -e ~/.adr-config ]
+then
+  if [ "$quiet" -eq 0 ]
+  then
+    echo "# Loading global values from ~/.adr-config"
+  fi
+  source ~/.adr-config
+fi
+if [ -e "$("${adr_bin_dir}/_adr_dir")/.adr-config" ]
+then
+  if [ "$quiet" -eq 0 ]
+  then
+      echo "# Loading local values from $("${adr_bin_dir}/_adr_dir")/.adr-config"
+  fi
+  source "$("${adr_bin_dir}/_adr_dir")/.adr-config"
+fi
+
+echo 'adr_bin_dir="'"${adr_bin_dir}"'"'
+echo 'adr_template_dir="'"${adr_template_dir}"'"'

--- a/tests/adr-config.expected
+++ b/tests/adr-config.expected
@@ -1,0 +1,68 @@
+adr config
+# This script returns the configuration values for adr-tools. It does not change these values.
+adr_bin_dir="/home/spriggsj/adr-tools-cp/src"
+adr_template_dir="/home/spriggsj/adr-tools-cp/src"
+
+adr config -q
+adr_bin_dir="/home/spriggsj/adr-tools-cp/src"
+adr_template_dir="/home/spriggsj/adr-tools-cp/src"
+
+echo "adr_template_dir='/usr/local/share/adr-tools'" | sudo tee /etc/adr-config >/dev/null
+adr config
+# This script returns the configuration values for adr-tools. It does not change these values.
+# Loading system values from /etc/adr-config
+adr_bin_dir="/home/spriggsj/adr-tools-cp/src"
+adr_template_dir="/usr/local/share/adr-tools"
+
+adr config -q
+adr_bin_dir="/home/spriggsj/adr-tools-cp/src"
+adr_template_dir="/usr/local/share/adr-tools"
+
+echo "adr_template_dir='/usr/local/share/adr-tools'" > ~/.adr-config
+adr config
+# This script returns the configuration values for adr-tools. It does not change these values.
+# Loading system values from /etc/adr-config
+# Loading global values from ~/.adr-config
+adr_bin_dir="/home/spriggsj/adr-tools-cp/src"
+adr_template_dir="/usr/local/share/adr-tools"
+
+adr config -q
+adr_bin_dir="/home/spriggsj/adr-tools-cp/src"
+adr_template_dir="/usr/local/share/adr-tools"
+
+mkdir -p doc/adr
+echo "adr_template_dir='/usr/local/share/adr-tools'" > doc/adr/.adr-config
+adr config
+# This script returns the configuration values for adr-tools. It does not change these values.
+# Loading system values from /etc/adr-config
+# Loading global values from ~/.adr-config
+# Loading local values from doc/adr/.adr-config
+adr_bin_dir="/home/spriggsj/adr-tools-cp/src"
+adr_template_dir="/usr/local/share/adr-tools"
+
+adr config -q
+adr_bin_dir="/home/spriggsj/adr-tools-cp/src"
+adr_template_dir="/usr/local/share/adr-tools"
+
+sudo rm /etc/adr-config
+adr config
+# This script returns the configuration values for adr-tools. It does not change these values.
+# Loading global values from ~/.adr-config
+# Loading local values from doc/adr/.adr-config
+adr_bin_dir="/home/spriggsj/adr-tools-cp/src"
+adr_template_dir="/usr/local/share/adr-tools"
+
+adr config -q
+adr_bin_dir="/home/spriggsj/adr-tools-cp/src"
+adr_template_dir="/usr/local/share/adr-tools"
+
+rm ~/.adr-config
+adr config
+# This script returns the configuration values for adr-tools. It does not change these values.
+# Loading local values from doc/adr/.adr-config
+adr_bin_dir="/home/spriggsj/adr-tools-cp/src"
+adr_template_dir="/usr/local/share/adr-tools"
+
+adr config -q
+adr_bin_dir="/home/spriggsj/adr-tools-cp/src"
+adr_template_dir="/usr/local/share/adr-tools"

--- a/tests/adr-config.sh
+++ b/tests/adr-config.sh
@@ -1,0 +1,29 @@
+adr config
+
+adr config -q
+
+echo "adr_template_dir='/usr/local/share/adr-tools'" | sudo tee /etc/adr-config >/dev/null
+adr config
+
+adr config -q
+
+echo "adr_template_dir='/usr/local/share/adr-tools'" > ~/.adr-config
+adr config
+
+adr config -q
+
+mkdir -p doc/adr
+echo "adr_template_dir='/usr/local/share/adr-tools'" > doc/adr/.adr-config
+adr config
+
+adr config -q
+
+sudo rm /etc/adr-config
+adr config
+
+adr config -q
+
+rm ~/.adr-config
+adr config
+
+adr config -q


### PR DESCRIPTION
Allow system, global and local config, similar to git configs

Viable config file paths are:
* System
  * `/etc/default/adr-config`
  * `/etc/adr-config`
* Global (user)
  * `~/.adr-config`
* Local (repo)
  * `$(_adr_dir)/.adr-config`

This change relies on `_adr_dir` not trying to load config, so
it also incorporates this removal, even though this may have been
removed in another branch/PR.

Tests are included. If it's not possible to run sudo based tests in
the CI/CD system, then these should be removed.