### PR TITLE
Make adr files recognition more stringent

### DIFF
--- a/src/adr-list
+++ b/src/adr-list
@@ -11,6 +11,7 @@ adr_dir=$("$adr_bin_dir/_adr_dir")
 if [ -d $adr_dir ]
 then
    find $adr_dir -maxdepth 1 -type f -exec basename {} \; | grep -E '^[0-9]*[1-9][0-9]*-[^/]*\.md$' | sort | sed -e "s?^?$adr_dir/?"
+   find $adr_dir -maxdepth 1 -type f | grep -E "^.{${#adr_dir}}/[0-9]*[1-9][0-9]*-[^/]*\\.md$" | sort
 else
     echo "The $adr_dir directory does not exist"
     exit 1

--- a/src/adr-list
+++ b/src/adr-list
@@ -10,7 +10,7 @@ adr_dir=$("$adr_bin_dir/_adr_dir")
 
 if [ -d $adr_dir ]
 then
-   find $adr_dir | grep -E "^$adr_dir/[0-9]+-[^/]*\\.md" | sort
+   find $adr_dir -maxdepth 1 -type f -exec basename {} \; | grep -E '^[0-9]*[1-9][0-9]*-[^/]*\.md$' | sort | sed -e "s?^?$adr_dir/?"
 else
     echo "The $adr_dir directory does not exist"
     exit 1


### PR DESCRIPTION
This fix makes `adr list` and `adr link` work properly when there are extraneous files along with adr files.

I just changed 
```shell
find $adr_dir | grep -E "^$adr_dir/[0-9]+-[^/]*\\.md" | sort
```
to
```shell
find $adr_dir -maxdepth 1 -type f -exec basename {} \; | grep -E '^[0-9]*[1-9][0-9]*-[^/]*\.md$' | sort | sed -e "s?^?$adr_dir/?"
```

Explanation:
- `-maxdepth 1`  exclude subfolders; this is faster if you have subfolders with a lot of files, for instance images linked by your ADRs
- `-type f` files only
- `-exec basename {} \;` remove adr_dir from the output so we can use single quote for grep expression avoiding complicated escape sequences due to both regex and shell double quoting. Also note that to be safe adr_dir itself should be escaped at runtime in the original code.
- `[0-9]*[1-9][0-9]*` any sequence of digits other than all zeros (0 is not a valid adr; for instance `adr new` starts from 1)
- `\.md$` make sure the extension is exactly `.md` (for instance `.md5` files are excluded)
- `sed -e "s?^?$adr_dir/?"` put  adr_dir back to the output 