### PR TITLE
Make adr files recognition stricter

### DIFF
--- a/src/adr-list
+++ b/src/adr-list
@@ -10,7 +10,7 @@ adr_dir=$("$adr_bin_dir/_adr_dir")
 
 if [ -d $adr_dir ]
 then
-   find $adr_dir | grep -E "^$adr_dir/[0-9]+-[^/]*\\.md" | sort
+   find $adr_dir -maxdepth 1 -type f | grep -E "^.{${#adr_dir}}/[0-9]*[1-9][0-9]*-[^/]*\\.md$" | sort
 else
     echo "The $adr_dir directory does not exist"
     exit 1


### PR DESCRIPTION
This fix makes `adr list` and `adr link` work properly when there are extraneous files along with adr files.

I just changed 
```shell
find $adr_dir | grep -E "^$adr_dir/[0-9]+-[^/]*\\.md" | sort
```
to
```shell
find $adr_dir -maxdepth 1 -type f | grep -E "^.{${#adr_dir}}/[0-9]*[1-9][0-9]*-[^/]*\\.md$" | sort
```

Explanation:
- `-maxdepth 1`  exclude subfolders; this is faster if you have subfolders with a lot of files, for instance images linked by your ADRs
- `-type f` files only
- `^.{${#adr_dir}}` skip as many chars as adr_dir length. This is more robust than matching the initial path with `^$adr_dir` because adr_dir might contain special regex chars that should be escaped at runtime.
- `[0-9]*[1-9][0-9]*` any sequence of digits other than all zeros (0 is not a valid adr; for instance `adr new` starts from 1)
- `\.md$` make sure the extension is exactly `.md` (for instance `.md5` files are excluded)