### PR TITLE
Fixed issue with .tmp not found

### DIFF
--- a/src/_adr_add_link
+++ b/src/_adr_add_link
@@ -25,4 +25,7 @@ awk -v link_type="$link_type" -v target="$(basename $target)" -v target_title="$
 	{ print }
 ' "$source" > "$source.tmp"
 
-mv "$source.tmp" "$source"
+if [ -e "$source.tmp" ];
+then
+  mv "$source.tmp" "$source"
+fi

--- a/src/_adr_remove_status
+++ b/src/_adr_remove_status
@@ -29,4 +29,7 @@ awk -v current_status="$current_status" '
 	{ print }
 ' "$file" > "$file.tmp"
 
-mv "$file.tmp" "$file"
+if [ -e "$file.tmp" ];
+then
+  mv "$file.tmp" "$file"
+fi


### PR DESCRIPTION
I got the following error when I ran the `adr new` command

```
$ adr new -s 9 Use Rust for performance-critical functionality
mv: rename .tmp to : No such file or directory
```

So I added an `if` condition and I ran the command again and it worked!

```
../doc/adr/0010-use-rust-for-performance-critical-functionality.md
```