### PR TITLE
add -r flag to toc generation

### DIFF
--- a/src/_adr_generate_toc
+++ b/src/_adr_generate_toc
@@ -10,36 +10,38 @@ eval "$($(dirname $0)/adr-config)"
 ##
 ## -i INTRO  precede the table of contents with the given INTRO text.
 ## -o OUTRO  follow the table of contents with the given OUTRO text.
-## -p LINK_PREFIX   
+## -p LINK_PREFIX
 ##           prefix each decision file link with LINK_PREFIX.
 ##
 ## Both INTRO and OUTRO must be in Markdown format.
 
-args=$(getopt i:o:p: $*)
+args=$(getopt i:o:p:r $*)
 set -- $args
 
 link_prefix=
 
-for arg
-do
-    case "$arg"
-    in
-        -i)
-            intro="$2"
-            shift 2
-            ;;
-        -o)
-            outro="$2"
-            shift 2
-            ;;
-        -p)
-            link_prefix="$2"
-            shift 2
-            ;;
-        --)
-            shift
-            break
-            ;;
+for arg; do
+    case "$arg" in
+    -r)
+        export REVERSE="-r"
+        shift 1
+        ;;
+    -i)
+        intro="$2"
+        shift 2
+        ;;
+    -o)
+        outro="$2"
+        shift 2
+        ;;
+    -p)
+        link_prefix="$2"
+        shift 2
+        ;;
+    --)
+        shift
+        break
+        ;;
     esac
 done
 
@@ -48,22 +50,19 @@ cat <<EOF
 
 EOF
 
-if [ ! -z $intro ]
-then
+if [ ! -z $intro ]; then
     cat "$intro"
     echo
 fi
 
-for f in $("$adr_bin_dir/adr-list")
-do
+for f in $("$adr_bin_dir/adr-list"); do
     title=$("$adr_bin_dir/_adr_title" $f)
     link=${link_prefix}$(basename $f)
 
     echo "* [$title]($link)"
 done
 
-if [ ! -z $outro ]
-then
+if [ ! -z $outro ]; then
     echo
     cat "$outro"
 fi

--- a/src/adr-list
+++ b/src/adr-list
@@ -8,11 +8,9 @@ eval "$($(dirname $0)/adr-config)"
 
 adr_dir=$("$adr_bin_dir/_adr_dir")
 
-if [ -d $adr_dir ]
-then
-   find $adr_dir | grep -E "^$adr_dir/[0-9]+-[^/]*\\.md" | sort
+if [ -d $adr_dir ]; then
+    find $adr_dir | grep -E "^$adr_dir/[0-9]+-[^/]*\\.md" | sort $REVERSE
 else
     echo "The $adr_dir directory does not exist"
     exit 1
 fi
-

--- a/tests/generate-contents-reversed.expected
+++ b/tests/generate-contents-reversed.expected
@@ -1,0 +1,12 @@
+adr new First Decision
+doc/adr/0001-first-decision.md
+adr new Second Decision
+doc/adr/0002-second-decision.md
+adr new Third Decision
+doc/adr/0003-third-decision.md
+adr generate toc -r
+# Architecture Decision Records
+
+* [3. Third Decision](0003-third-decision.md)
+* [2. Second Decision](0002-second-decision.md)
+* [1. First Decision](0001-first-decision.md)

--- a/tests/generate-contents-reversed.sh
+++ b/tests/generate-contents-reversed.sh
@@ -1,0 +1,4 @@
+adr new First Decision
+adr new Second Decision
+adr new Third Decision
+adr generate toc -r


### PR DESCRIPTION
This PR adds `-r` flag to `generate toc` command - allowing for generating TOC in reverse order.

This is a valid use case - you want newest decisions to be on top of README file in the repo.