### PR TITLE
Solved _add_dir script error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 build/
+
+#
+# macOS file system
+#
+.DS_Store

--- a/src/_adr_dir
+++ b/src/_adr_dir
@@ -13,7 +13,7 @@ function absdir() {
 	(cd $(dirname $1) && pwd -P)
 }
 
-while [ $(absdir $reldir) != / ]
+while [ "$(absdir $reldir)" != / ]
 do
 	if [ -f $(mkrel .adr-dir) ]
 	then


### PR DESCRIPTION
## Script 

If the adr documentation path contains blank spaces the scripts fail. 

```sh
/opt/homebrew/Cellar/adr-tools/3.0.0/bin/_adr_dir: line 16: [: too many arguments
```

The solution is enclose the script variable located at line 16 into quotes

```sh
while [ "$(absdir $reldir)" != / ]
```

## gitignore

Added .DS_Store macOS files to the `.gitignore` file