### PR TITLE
Enhance `_adr_title` to allow using metadata in the adr file

### DIFF
--- a/src/_adr_title
+++ b/src/_adr_title
@@ -2,4 +2,4 @@
 set -e
 eval "$($(dirname $0)/adr-config)"
 
-head -1 $("$adr_bin_dir/_adr_file" "$1") | cut -c 3-
+cat $("$adr_bin_dir/_adr_file" "$1") | grep '^# ' | cut -c 3-


### PR DESCRIPTION
Our adr files needs to be synchronised into Confluence, but we got into troubles using [mark](https://github.com/kovetskiy/mark) which needs some metadata

```
<!-- Space: CON -->
<!-- Parent: Documentation -->
<!-- Parent: ADRs -->
<!-- Title: 1. Record architecture decisions -->

# 1. Record architecture decisions
```

In this case `_adr_title` will produce `-- Space: CON -->`