### PR TITLE
Fix: strip _any_ trailing line break character from the titles

### DIFF
--- a/src/_adr_title
+++ b/src/_adr_title
@@ -2,4 +2,4 @@
 set -e
 eval "$($(dirname $0)/adr-config)"
 
-head -1 $("$adr_bin_dir/_adr_file" "$1") | cut -c 3-
+head -1 $("$adr_bin_dir/_adr_file" "$1") | cut -c 3- | tr -d '\r\n'


### PR DESCRIPTION
Otherwise, when parsing *.md files with windows-style line breaks (CR-LF), one of the line break characters would remain in the title, thus breaking the markup for the table of content.