### PR TITLE
docs: Fix (widely considered to be) incorrect spelling

### DIFF
--- a/src/adr-new
+++ b/src/adr-new
@@ -114,9 +114,9 @@ cat $template | sed \
 
 for target in "${superceded[@]}"
 do
-	"$adr_bin_dir/_adr_add_link" "$target" "Superceded by" "$dstfile"
+	"$adr_bin_dir/_adr_add_link" "$target" "Superseded by" "$dstfile"
 	"$adr_bin_dir/_adr_remove_status" "Accepted" "$target"
-	"$adr_bin_dir/_adr_add_link" "$dstfile" "Supercedes" "$target"
+	"$adr_bin_dir/_adr_add_link" "$dstfile" "Supersedes" "$target"
 done
 
 for l in "${links[@]}"


### PR DESCRIPTION
"Supercede" is [considered to be erroneous](https://www.merriam-webster.com/dictionary/supercede). Although it might be correct, many spellcheckers will highlight it as error. 
Since this is an import field in the ADR that should ideally be left untouched, I'd I recommend to rename it to the more correct spelling.