### PR TITLE
Add script for adding table that contains ADR name and status

### DIFF
--- a/src/_adr_generate_table
+++ b/src/_adr_generate_table
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+eval "$($(dirname $0)/adr-config)"
+
+## usage: adr generate table [-i INTRO] [-o OUTRO] [-p LINK_PREFIX]
+##
+## Generates a table in Markdown format to stdout that contains the ADR name and status.
+##
+## Options:
+##
+## -i INTRO  precede the table of contents with the given INTRO text.
+## -o OUTRO  follow the table of contents with the given OUTRO text.
+## -p LINK_PREFIX   
+##           prefix each decision file link with LINK_PREFIX.
+##
+## Both INTRO and OUTRO must be in Markdown format.
+
+args=$(getopt i:o:p: $*)
+set -- $args
+
+link_prefix=
+
+for arg
+do
+    case "$arg"
+    in
+        -i)
+            intro="$2"
+            shift 2
+            ;;
+        -o)
+            outro="$2"
+            shift 2
+            ;;
+        -p)
+            link_prefix="$2"
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+    esac
+done
+
+if [ ! -z $intro ]
+then
+    cat "$intro"
+    echo
+fi
+
+cat <<EOF
+## Architecture Decision Records
+
+EOF
+
+echo "|ADR|Status|"
+echo "|---|---|"
+for f in $("$adr_bin_dir/adr-list")
+do
+    title=$("$adr_bin_dir/_adr_title" $f)
+    link=${link_prefix}$(basename $f)
+    status=$("$adr_bin_dir/_adr_status" $f)
+
+    echo "|[$title]($link)|$status|"
+done
+
+if [ ! -z $outro ]
+then
+    echo
+    cat "$outro"
+fi

--- a/src/_adr_generate_table
+++ b/src/_adr_generate_table
@@ -8,8 +8,8 @@ eval "$($(dirname $0)/adr-config)"
 ##
 ## Options:
 ##
-## -i INTRO  precede the table of contents with the given INTRO text.
-## -o OUTRO  follow the table of contents with the given OUTRO text.
+## -i INTRO  precede the table with the given INTRO text.
+## -o OUTRO  follow the table with the given OUTRO text.
 ## -p LINK_PREFIX   
 ##           prefix each decision file link with LINK_PREFIX.
 ##
@@ -48,11 +48,6 @@ then
     cat "$intro"
     echo
 fi
-
-cat <<EOF
-## Architecture Decision Records
-
-EOF
 
 echo "|ADR|Status|"
 echo "|---|---|"


### PR DESCRIPTION
Looking for a way to create a toc that also contains the ADR status, I just created a new script that generates such a table.

The usage would be `adr generate table`