### PR TITLE
Replace backticks in help doc

### DIFF
--- a/src/_adr_help_new
+++ b/src/_adr_help_new
@@ -12,7 +12,7 @@ preferred; EDITOR is used if VISUAL is not set).  After editing, the
 file name of the ADR is output to stdout, so the command can be used in
 scripts.
 
-If the ADR directory contains a file `templates/template.md`, this is used as
+If the ADR directory contains a file "templates/template.md", this is used as
 the template for the new ADR.  Otherwise the following file is used:
 
   ${adr_template_dir}/template.md


### PR DESCRIPTION
The backticks were being run, resulting in a blank space in output of `adr help new` rather than the formatting that was likely being attempted.