### PR TITLE
fix default template order

### DIFF
--- a/src/template.md
+++ b/src/template.md
@@ -2,18 +2,24 @@
 
 Date: DATE
 
+## Context
+
+[//]: # (The issue motivating this decision, and any context that influences or constrains the decision.)
+
+
+
+## Decision
+
+[//]: # (The change that we're proposing or have agreed to implement.)
+
+
+
 ## Status
 
 STATUS
 
-## Context
-
-The issue motivating this decision, and any context that influences or constrains the decision.
-
-## Decision
-
-The change that we're proposing or have agreed to implement.
-
 ## Consequences
 
-What becomes easier or more difficult to do and any risks introduced by the change that will need to be mitigated.
+[//]: # (What becomes easier or more difficult to do and any risks introduced by the change that will need to be mitigated.)
+
+


### PR DESCRIPTION
Amends default template order to align with the order set out in the defining document, [DAD](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions).

Additionally,
- puts section descriptions in comments.
- adds additional empty lines after section descriptions.

This removes the need for section descriptions to be deleted before adding real content.

## NB

This partially reverts 0549c4a which moved status to the top without any explanation, _such as an ADR_, as to why. Several years later, I appreciate that, to some, this could now be regarded as a "breaking" change, however, we should not [927](https://xkcd.com/927/) things without proper due diligence.

resolves #149 