### PR TITLE
Provide asdf plugin commands in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,9 @@ ASDF-VM (Linux, MacOS X)
 
 ADR-Tools can be installed from the [ASDF-VM version manager](https://github.com/asdf-vm/asdf).
 
+    asdf plugin add adr-tools
+    asdf install adr-tools latest
+
 From a Release Package (Linux, MacOS X)
 ---------------------------------------
 


### PR DESCRIPTION
Update INSTALL.md to provide the asdf installation commands  required to install the latest adm-tools. 1) so that we are consistent with the homebrew section and 2) So that we save the next person a few minutes.